### PR TITLE
Expand village and widen camera view

### DIFF
--- a/index.html
+++ b/index.html
@@ -781,12 +781,12 @@
 
         // Camera (Top-down Ortho)
         const aspect = window.innerWidth / window.innerHeight;
-        const viewSize = 30;
+        const viewSize = 60;
         const camera = new THREE.OrthographicCamera(
             -viewSize * aspect / 2, viewSize * aspect / 2,
             viewSize / 2, -viewSize / 2, 1, 1000
         );
-        camera.position.set(0, 50, 0);
+        camera.position.set(0, 50, 100);
         camera.lookAt(0, 0, 0);
         scene.add(camera);
 
@@ -981,6 +981,9 @@
         const road = new THREE.Mesh(roadGeometry, roadMaterial); road.scale.y = 0.05; road.position.y = 0.1; road.receiveShadow = true; scene.add(road);
 
         // Town buildings
+        const village = new THREE.Group();
+        scene.add(village);
+
         function createBuilding(w, h, d, color, roofColor) {
             const group = new THREE.Group();
             const base = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), new THREE.MeshStandardMaterial({ color }));
@@ -989,12 +992,12 @@
             roof.position.y = h / 2 + h * 0.25; roof.rotation.y = Math.PI / 4; roof.castShadow = true; group.add(roof);
             return group;
         }
-        const house1 = createBuilding(6,4,6,0xb5651d,0x8b0000); house1.position.set(-12,0,8); scene.add(house1);
-        const shop = createBuilding(6,4,6,0x996633,0x555555); shop.position.set(12,0,-8); scene.add(shop);
-        const inn = createBuilding(8,5,8,0xcd853f,0x654321); inn.position.set(0,0,10); scene.add(inn);
-        const stable = createBuilding(5,3,7,0xdeb887,0x8b4513); stable.position.set(20,0,-12); scene.add(stable);
+        const house1 = createBuilding(6,4,6,0xb5651d,0x8b0000); house1.position.set(-12,0,8); village.add(house1);
+        const shop = createBuilding(6,4,6,0x996633,0x555555); shop.position.set(12,0,-8); village.add(shop);
+        const inn = createBuilding(8,5,8,0xcd853f,0x654321); inn.position.set(0,0,10); village.add(inn);
+        const stable = createBuilding(5,3,7,0xdeb887,0x8b4513); stable.position.set(20,0,-12); village.add(stable);
         const dungeonEntrance = new THREE.Mesh(new THREE.CylinderGeometry(2,2,4,8,1,true), new THREE.MeshStandardMaterial({ color: 0x333333, side: THREE.DoubleSide }));
-        dungeonEntrance.position.set(30,2,-10); dungeonEntrance.castShadow = true; scene.add(dungeonEntrance);
+        dungeonEntrance.position.set(30,2,-10); dungeonEntrance.castShadow = true; village.add(dungeonEntrance);
         let inDungeon = false;
 
         // Instanced trees, rocks
@@ -1039,7 +1042,7 @@
             house.position.set(x, 0, z);
             return house;
         });
-        houses.forEach(h => scene.add(h));
+        houses.forEach(h => village.add(h));
 
         // Central roads
         function createRoad(x, z, width, height) {
@@ -1050,7 +1053,7 @@
             road.rotation.x = -Math.PI / 2;
             road.position.set(x, 0.01, z);
             road.receiveShadow = true;
-            scene.add(road);
+            village.add(road);
             return road;
         }
         createRoad(0, 0, 40, 4);  // east-west road
@@ -1064,13 +1067,13 @@
         for (let angle = 0; angle < Math.PI * 2; angle += fenceStep) {
             const post = new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0.3, 2, 6), fenceMaterial);
             post.position.set(Math.cos(angle) * fenceRadius, 1, Math.sin(angle) * fenceRadius);
-            post.castShadow = true; scene.add(post);
+            post.castShadow = true; village.add(post);
 
             const midAngle = angle + fenceStep / 2;
             const rail = new THREE.Mesh(new THREE.BoxGeometry(railLength, 0.2, 0.2), fenceMaterial);
             rail.position.set(Math.cos(midAngle) * fenceRadius, 1.2, Math.sin(midAngle) * fenceRadius);
             rail.rotation.y = midAngle + Math.PI / 2;
-            rail.castShadow = true; scene.add(rail);
+            rail.castShadow = true; village.add(rail);
         }
 
         // Market stalls
@@ -1090,7 +1093,7 @@
             return stall;
         }
         const stalls = [createStall(8, 0), createStall(-8, 0)];
-        stalls.forEach(s => scene.add(s));
+        stalls.forEach(s => village.add(s));
 
         // Village well
         const well = new THREE.Group();
@@ -1098,11 +1101,14 @@
         wellBase.position.y = 1; wellBase.castShadow = true; wellBase.receiveShadow = true; well.add(wellBase);
         const wellRoof = new THREE.Mesh(new THREE.ConeGeometry(2.5, 2, 4), new THREE.MeshStandardMaterial({ color: 0x654321 }));
         wellRoof.position.y = 3; wellRoof.rotation.y = Math.PI / 4; wellRoof.castShadow = true; well.add(wellRoof);
-        well.position.set(0, 0, 0); scene.add(well);
+        well.position.set(0, 0, 0); village.add(well);
 
         // Farmland patch
         const farm = new THREE.Mesh(new THREE.PlaneGeometry(10, 10), new THREE.MeshStandardMaterial({ color: 0x8B4513 }));
-        farm.rotation.x = -Math.PI / 2; farm.position.set(20, 0, 0); farm.receiveShadow = true; scene.add(farm);
+        farm.rotation.x = -Math.PI / 2; farm.position.set(20, 0, 0); farm.receiveShadow = true; village.add(farm);
+
+        // Scale up the entire village
+        village.scale.set(1.5, 1.5, 1.5);
 
         // Ambient particles
         const particleCount = 500;
@@ -1883,7 +1889,7 @@
             checkDungeonEntrance();
 
             camera.position.x = player.position.x;
-            camera.position.z = player.position.z + 50;
+            camera.position.z = player.position.z + 100;
             camera.lookAt(player.position);
 
             // Interactibles

--- a/narrative_quest_minibattle_gear_patched_FIXED.html
+++ b/narrative_quest_minibattle_gear_patched_FIXED.html
@@ -745,12 +745,12 @@
 
         // Camera (Top-down Ortho)
         const aspect = window.innerWidth / window.innerHeight;
-        const viewSize = 30;
+        const viewSize = 60;
         const camera = new THREE.OrthographicCamera(
             -viewSize * aspect / 2, viewSize * aspect / 2,
             viewSize / 2, -viewSize / 2, 1, 1000
         );
-        camera.position.set(0, 50, 0);
+        camera.position.set(0, 50, 100);
         camera.lookAt(0, 0, 0);
         scene.add(camera);
 
@@ -1587,7 +1587,7 @@
             }
 
             camera.position.x = player.position.x;
-            camera.position.z = player.position.z + 50;
+            camera.position.z = player.position.z + 100;
             camera.lookAt(player.position);
 
             // Interactibles


### PR DESCRIPTION
## Summary
- Group village structures together and scale the entire village to feel larger
- Increase orthographic camera view and move it farther back for wider perspective
- Apply camera distance changes to alternate demo file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1f47b7d0083248e3cdede3ef04973