### PR TITLE
Add fishing village near the sea

### DIFF
--- a/index.html
+++ b/index.html
@@ -1311,6 +1311,50 @@
         // Scale up the entire village
         village.scale.set(1.5, 1.5, 1.5);
 
+        // --- FISHING VILLAGE NEAR THE SEA ---
+        const fishingVillage = new THREE.Group();
+        fishingVillage.position.set(-80, 0, -150);
+        scene.add(fishingVillage);
+
+        // Water plane representing the sea
+        const sea = new THREE.Mesh(
+            new THREE.PlaneGeometry(200, 200),
+            new THREE.MeshStandardMaterial({ color: 0x1e90ff, transparent: true, opacity: 0.7 })
+        );
+        sea.rotation.x = -Math.PI / 2;
+        sea.position.set(0, -0.1, -50);
+        fishingVillage.add(sea);
+
+        // Simple huts for the fishing village
+        function createHut(x, z) {
+            const hut = createBuilding(4, 3, 4, 0x9b7653, 0x8b4513);
+            hut.position.set(x, 0, z);
+            return hut;
+        }
+        [createHut(-12, 20), createHut(12, 20)].forEach(h => fishingVillage.add(h));
+
+        // Wooden dock extending into the sea
+        const dock = new THREE.Mesh(new THREE.BoxGeometry(20, 0.5, 4), new THREE.MeshStandardMaterial({ color: 0x8B5A2B }));
+        dock.position.set(0, 0.25, -20);
+        fishingVillage.add(dock);
+        for (let i = -9; i <= 9; i += 6) {
+            const post = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.3, 2, 8), fenceMaterial);
+            post.position.set(i, 1, -22);
+            post.castShadow = true;
+            fishingVillage.add(post);
+        }
+
+        // Boats floating on the water
+        function createBoat(x, z) {
+            const boat = new THREE.Group();
+            const hull = new THREE.Mesh(new THREE.BoxGeometry(4, 0.8, 1.5), new THREE.MeshStandardMaterial({ color: 0x654321 }));
+            hull.position.y = 0.4;
+            boat.add(hull);
+            boat.position.set(x, 0, z);
+            return boat;
+        }
+        [createBoat(-6, -40), createBoat(6, -45)].forEach(b => fishingVillage.add(b));
+
         // Ambient particles
         const particleCount = 500;
         const particlesGeometry = new THREE.BufferGeometry();


### PR DESCRIPTION
## Summary
- add new fishing village group near the sea with water plane
- create huts, dock, and boats to evoke a fishing village vibe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c293e53cf483249b3ed429ee8a8cf5