### PR TITLE
Add village structure assets and terrain placement

### DIFF
--- a/assets/models/villageStructures.js
+++ b/assets/models/villageStructures.js
@@ -1,0 +1,68 @@
+import * as THREE from 'three';
+
+// Pastel-colored low-poly assets for village structures
+
+export function createHut() {
+    const group = new THREE.Group();
+    const base = new THREE.Mesh(
+        new THREE.BoxGeometry(4, 3, 4),
+        new THREE.MeshStandardMaterial({ color: 0xF2D6B3, flatShading: true })
+    );
+    base.castShadow = true; base.receiveShadow = true; group.add(base);
+    const roof = new THREE.Mesh(
+        new THREE.ConeGeometry(3, 2, 4),
+        new THREE.MeshStandardMaterial({ color: 0xC9A36B, flatShading: true })
+    );
+    roof.position.y = 2.5; roof.rotation.y = Math.PI / 4; roof.castShadow = true; group.add(roof);
+    return group;
+}
+
+export function createFarmRow() {
+    const row = new THREE.Mesh(
+        new THREE.BoxGeometry(8, 0.2, 2),
+        new THREE.MeshStandardMaterial({ color: 0xC9E4B4, flatShading: true })
+    );
+    row.receiveShadow = true;
+    return row;
+}
+
+export function createLordHouse() {
+    const group = new THREE.Group();
+    const base = new THREE.Mesh(
+        new THREE.BoxGeometry(8, 5, 8),
+        new THREE.MeshStandardMaterial({ color: 0xF5E0C3, flatShading: true })
+    );
+    base.castShadow = true; base.receiveShadow = true; group.add(base);
+    const roof = new THREE.Mesh(
+        new THREE.ConeGeometry(6, 3, 4),
+        new THREE.MeshStandardMaterial({ color: 0xC58B8B, flatShading: true })
+    );
+    roof.position.y = 4; roof.rotation.y = Math.PI / 4; roof.castShadow = true; group.add(roof);
+    return group;
+}
+
+export function createChurch() {
+    const group = new THREE.Group();
+    const base = new THREE.Mesh(
+        new THREE.BoxGeometry(6, 4, 10),
+        new THREE.MeshStandardMaterial({ color: 0xE3E3F7, flatShading: true })
+    );
+    base.castShadow = true; base.receiveShadow = true; group.add(base);
+    const roof = new THREE.Mesh(
+        new THREE.ConeGeometry(5, 4, 4),
+        new THREE.MeshStandardMaterial({ color: 0xA3C9F5, flatShading: true })
+    );
+    roof.position.set(0, 4, 0); roof.rotation.y = Math.PI / 4; roof.castShadow = true; group.add(roof);
+    const steeple = new THREE.Mesh(
+        new THREE.BoxGeometry(1, 3, 1),
+        new THREE.MeshStandardMaterial({ color: 0xE3E3F7, flatShading: true })
+    );
+    steeple.position.set(0, 6, 0); steeple.castShadow = true; steeple.receiveShadow = true; group.add(steeple);
+    const crossMat = new THREE.MeshStandardMaterial({ color: 0xC58B8B, flatShading: true });
+    const cross = new THREE.Mesh(new THREE.BoxGeometry(0.2, 1.5, 0.2), crossMat);
+    cross.position.set(0, 7.5, 0); group.add(cross);
+    const crossBar = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.2, 0.2), crossMat);
+    crossBar.position.set(0, 7.2, 0); group.add(crossBar);
+    return group;
+}
+

--- a/index.html
+++ b/index.html
@@ -521,6 +521,7 @@
     <script type="module">
         import * as THREE from 'three';
         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+        import { createHut, createFarmRow, createLordHouse, createChurch } from './assets/models/villageStructures.js';
 
         // --- GEMINI API SETUP ---
         const LLM_API_URL = '/gemini';
@@ -1132,6 +1133,51 @@
         const groundGeometry = new THREE.PlaneGeometry(500, 500);
         const groundMaterial = new THREE.MeshStandardMaterial({ color: 0x4F7942 });
         const ground = new THREE.Mesh(groundGeometry, groundMaterial); ground.rotation.x = -Math.PI/2; ground.receiveShadow = true; scene.add(ground);
+
+        const TILE_SIZE = 10;
+        const referenceLayout = {
+            huts: [
+                { x: 1, z: 1 },
+                { x: 3, z: 1 },
+                { x: 1, z: 3 },
+                { x: 3, z: 3 }
+            ],
+            farmRows: [
+                { x: 5, z: 0 },
+                { x: 5, z: 1 },
+                { x: 5, z: 2 },
+                { x: 5, z: 3 }
+            ],
+            lordHouse: { x: 2, z: 2 },
+            church: { x: 2, z: 4 }
+        };
+
+        function generateTerrain() {
+            const layoutGroup = new THREE.Group();
+            scene.add(layoutGroup);
+
+            referenceLayout.huts.forEach(pos => {
+                const hut = createHut();
+                hut.position.set(pos.x * TILE_SIZE, 0, pos.z * TILE_SIZE);
+                layoutGroup.add(hut);
+            });
+
+            referenceLayout.farmRows.forEach(pos => {
+                const row = createFarmRow();
+                row.position.set(pos.x * TILE_SIZE, 0, pos.z * TILE_SIZE);
+                layoutGroup.add(row);
+            });
+
+            const lord = createLordHouse();
+            lord.position.set(referenceLayout.lordHouse.x * TILE_SIZE, 0, referenceLayout.lordHouse.z * TILE_SIZE);
+            layoutGroup.add(lord);
+
+            const church = createChurch();
+            church.position.set(referenceLayout.church.x * TILE_SIZE, 0, referenceLayout.church.z * TILE_SIZE);
+            layoutGroup.add(church);
+        }
+
+        generateTerrain();
 
         function createGravelTexture() {
             const canvas = document.createElement('canvas'); canvas.width = 256; canvas.height = 256;


### PR DESCRIPTION
## Summary
- add pastel low-poly models for huts, farm rows, lord's house, and church
- generate terrain that places these structures at fixed tile coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2951beae88324882a2031839c208e