### PR TITLE
Replace models with billboarded sprites

### DIFF
--- a/assets/sprites/knight.svg
+++ b/assets/sprites/knight.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="32">
+  <!-- Idle frames -->
+  <rect x="0" y="0" width="32" height="32" fill="#888888"/>
+  <rect x="32" y="0" width="32" height="32" fill="#aaaaaa"/>
+  <!-- Walk frames -->
+  <rect x="64" y="0" width="32" height="32" fill="#0000cc"/>
+  <rect x="96" y="0" width="32" height="32" fill="#0000ff"/>
+  <!-- Farm/Action frames -->
+  <rect x="128" y="0" width="32" height="32" fill="#cc0000"/>
+  <rect x="160" y="0" width="32" height="32" fill="#ff0000"/>
+</svg>

--- a/assets/sprites/monk.svg
+++ b/assets/sprites/monk.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="32">
+  <!-- Idle frames -->
+  <rect x="0" y="0" width="32" height="32" fill="#663399"/>
+  <rect x="32" y="0" width="32" height="32" fill="#7b4bb2"/>
+  <!-- Walk frames -->
+  <rect x="64" y="0" width="32" height="32" fill="#d2691e"/>
+  <rect x="96" y="0" width="32" height="32" fill="#ff8c00"/>
+  <!-- Farm/Chant frames -->
+  <rect x="128" y="0" width="32" height="32" fill="#ffd700"/>
+  <rect x="160" y="0" width="32" height="32" fill="#ffe347"/>
+</svg>

--- a/assets/sprites/peasant.svg
+++ b/assets/sprites/peasant.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="32">
+  <!-- Idle frames -->
+  <rect x="0" y="0" width="32" height="32" fill="#8b4513"/>
+  <rect x="32" y="0" width="32" height="32" fill="#a0522d"/>
+  <!-- Walk frames -->
+  <rect x="64" y="0" width="32" height="32" fill="#cd853f"/>
+  <rect x="96" y="0" width="32" height="32" fill="#deb887"/>
+  <!-- Farm frames -->
+  <rect x="128" y="0" width="32" height="32" fill="#228b22"/>
+  <rect x="160" y="0" width="32" height="32" fill="#32cd32"/>
+</svg>

--- a/characters.js
+++ b/characters.js
@@ -1,0 +1,55 @@
+import * as THREE from 'three';
+
+export class SpriteCharacter extends THREE.Sprite {
+  constructor(textureURL, options = {}) {
+    const loader = new THREE.TextureLoader();
+    const texture = loader.load(textureURL);
+    texture.magFilter = THREE.NearestFilter;
+    texture.minFilter = THREE.NearestFilter;
+    texture.wrapS = THREE.RepeatWrapping;
+    texture.wrapT = THREE.RepeatWrapping;
+    const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+    super(material);
+
+    this.texture = texture;
+    this.columns = options.columns || 6;
+    this.animations = options.animations || { idle: [0], walk: [1], farm: [2] };
+    this.frameTime = options.frameTime || 0.2;
+    this.currentAnim = 'idle';
+    this.currentFrameIndex = 0;
+    this.elapsed = 0;
+
+    const scale = options.scale || 5;
+    this.scale.set(scale, scale, 1);
+    this.center.set(0.5, 0);
+    this.updateFrame();
+  }
+
+  updateFrame() {
+    const frames = this.animations[this.currentAnim];
+    const frame = frames[this.currentFrameIndex];
+    const col = frame % this.columns;
+    // single row sprite sheet
+    this.texture.repeat.set(1 / this.columns, 1);
+    this.texture.offset.set(col / this.columns, 0);
+  }
+
+  setAnimation(name) {
+    if (!this.animations[name] || this.currentAnim === name) return;
+    this.currentAnim = name;
+    this.currentFrameIndex = 0;
+    this.elapsed = 0;
+    this.updateFrame();
+  }
+
+  update(delta, camera) {
+    this.quaternion.copy(camera.quaternion);
+    this.elapsed += delta;
+    if (this.elapsed >= this.frameTime) {
+      this.elapsed = 0;
+      const frames = this.animations[this.currentAnim];
+      this.currentFrameIndex = (this.currentFrameIndex + 1) % frames.length;
+      this.updateFrame();
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -520,7 +520,7 @@
     </script>
     <script type="module">
         import * as THREE from 'three';
-        import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+        import { SpriteCharacter } from './characters.js';
 
         // --- GEMINI API SETUP ---
         const LLM_API_URL = '/gemini';
@@ -606,6 +606,18 @@
             who: ["my guardian","the elder","the fisherman","the Sage","the village"],
             goal: ["protect the village","find the source","calm the tides","reach the lighthouse"],
             obstacle: ["toxic fog","ravenous current","whispering shadows","shattered reef"]
+        };
+
+        const SPRITE_SHEETS = {
+            knight: 'assets/sprites/knight.svg',
+            peasant: 'assets/sprites/peasant.svg',
+            monk: 'assets/sprites/monk.svg'
+        };
+
+        const SPRITE_ANIMATIONS = {
+            idle: [0,1],
+            walk: [2,3],
+            farm: [4,5]
         };
 
         // Player outfit textures
@@ -858,104 +870,6 @@
         let torch;
 
         // Character factory that loads a humanoid model or falls back to primitives
-        function createCharacterModel(
-            skinColor = 0xffddbb,
-            shirtColor = 0x888888,
-            pantsColor = shirtColor,
-            hairColor = 0x333333
-        ) {
-            const group = new THREE.Group();
-            const loader = new GLTFLoader();
-            const modelUrl = 'models/humanoid.glb';
-
-            const buildPrimitive = () => {
-                const pGroup = new THREE.Group();
-                const shirtMat = new THREE.MeshStandardMaterial({ color: shirtColor });
-                const skinMat = new THREE.MeshStandardMaterial({ color: skinColor });
-                const pantsMat = new THREE.MeshStandardMaterial({ color: pantsColor });
-                const hairMat = new THREE.MeshStandardMaterial({ color: hairColor });
-
-                const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.8, 1.6, 8, 16), shirtMat);
-                body.castShadow = true; body.receiveShadow = true; body.position.y = 1.8; pGroup.add(body);
-
-                const head = new THREE.Mesh(new THREE.SphereGeometry(0.6, 16, 16), skinMat.clone());
-                head.position.y = 3.5; head.castShadow = true; pGroup.add(head);
-
-                const hair = new THREE.Mesh(new THREE.SphereGeometry(0.62, 16, 16), hairMat);
-                hair.position.y = 4.1; hair.castShadow = true; pGroup.add(hair);
-
-                // simple facial features
-                const eyeGeom = new THREE.SphereGeometry(0.1, 8, 8);
-                const eyeMat = new THREE.MeshStandardMaterial({ color: 0xffffff });
-                const leftEye = new THREE.Mesh(eyeGeom, eyeMat);
-                const rightEye = new THREE.Mesh(eyeGeom, eyeMat);
-                leftEye.position.set(-0.2, 0.1, 0.55);
-                rightEye.position.set(0.2, 0.1, 0.55);
-                head.add(leftEye); head.add(rightEye);
-                const mouth = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.05, 0.05), new THREE.MeshStandardMaterial({ color: 0x000000 }));
-                mouth.position.set(0, -0.2, 0.55); head.add(mouth);
-                const nose = new THREE.Mesh(new THREE.ConeGeometry(0.08, 0.2, 8), skinMat.clone());
-                nose.rotation.x = Math.PI / 2;
-                nose.position.set(0, -0.05, 0.6);
-                head.add(nose);
-                const earGeom = new THREE.SphereGeometry(0.12, 8, 8);
-                const leftEar = new THREE.Mesh(earGeom, skinMat.clone());
-                const rightEar = new THREE.Mesh(earGeom, skinMat.clone());
-                leftEar.position.set(-0.6, 0, 0);
-                rightEar.position.set(0.6, 0, 0);
-                head.add(leftEar); head.add(rightEar);
-
-                // limbs
-                const armGeom = new THREE.CapsuleGeometry(0.15, 1.0, 4, 8);
-                const legGeom = new THREE.CapsuleGeometry(0.2, 1.2, 4, 8);
-                const leftArm = new THREE.Mesh(armGeom, shirtColor === skinColor ? skinMat.clone() : shirtMat.clone());
-                const rightArm = new THREE.Mesh(armGeom, shirtColor === skinColor ? skinMat.clone() : shirtMat.clone());
-                leftArm.position.set(-0.9, 1.2, 0);
-                rightArm.position.set(0.9, 1.2, 0);
-                const leftLeg = new THREE.Mesh(legGeom, pantsMat.clone());
-                const rightLeg = new THREE.Mesh(legGeom, pantsMat.clone());
-                leftLeg.position.set(-0.4, 0, 0);
-                rightLeg.position.set(0.4, 0, 0);
-                [leftArm, rightArm, leftLeg, rightLeg].forEach(l => { l.castShadow = true; pGroup.add(l); });
-                pGroup.userData = { arms: [leftArm, rightArm], legs: [leftLeg, rightLeg] };
-                return pGroup;
-            };
-
-            loader.load(
-                modelUrl,
-                gltf => {
-                    const model = gltf.scene;
-                    model.traverse(obj => {
-                        if (obj.isMesh) {
-                            obj.castShadow = true;
-                            obj.receiveShadow = true;
-                            const name = obj.name.toLowerCase();
-                            const mat = obj.material.clone();
-                            if (name.includes('skin') || name.includes('body') || name.includes('head')) {
-                                mat.color.setHex(skinColor);
-                            } else if (name.includes('shirt') || name.includes('top')) {
-                                mat.color.setHex(shirtColor);
-                            } else if (name.includes('pant') || name.includes('leg')) {
-                                mat.color.setHex(pantsColor);
-                            } else if (name.includes('hair')) {
-                                mat.color.setHex(hairColor);
-                            }
-                            obj.material = mat;
-                        }
-                    });
-                    group.add(model);
-                },
-                undefined,
-                error => {
-                    console.warn('Failed to load humanoid model, using primitives instead.', error);
-                    const primitive = buildPrimitive();
-                    group.add(primitive);
-                }
-            );
-
-            return group;
-        }
-
         function createTorch() {
             const group = new THREE.Group();
             const handle = new THREE.Mesh(
@@ -1017,63 +931,40 @@
 
         const wanderers = [];
         function addWanderer(obj, radius) {
+            if (obj.setAnimation) obj.setAnimation('walk');
             wanderers.push({ obj, radius, angle: Math.random() * Math.PI * 2, speed: Math.random() * 0.5 + 0.2, center: obj.position.clone() });
-        }
-
-        function animateLimbs(character, t) {
-            if (!character.userData || !character.userData.arms) return;
-            character.userData.arms[0].rotation.x = Math.sin(t) * 0.5;
-            character.userData.arms[1].rotation.x = -Math.sin(t) * 0.5;
-            character.userData.legs[0].rotation.x = -Math.sin(t) * 0.5;
-            character.userData.legs[1].rotation.x = Math.sin(t) * 0.5;
         }
 
         let encounterDistance = 0;
 
         // Player & NPCs
-        const player = createCharacterModel(0xffeecc, 0xffff00, 0x0000ff, 0x000000); player.position.set(0, 0, 20); scene.add(player);
+        const player = new SpriteCharacter(SPRITE_SHEETS.knight, { animations: SPRITE_ANIMATIONS, scale:5 });
+        player.position.set(0, 0, 20);
+        player.setAnimation('idle');
+        scene.add(player);
         torch = createTorch();
-        if (player.userData && player.userData.arms) {
-            player.userData.arms[1].add(torch);
-            torch.position.set(0, -0.6, 0);
-        } else {
-            player.add(torch);
-            torch.position.set(0, 2.5, 1);
-        }
-
-        // Diverse NPC outfits and explicit assignments
-        const npcOutfits = [
-            { shirt:0x0000ff, pants:0x333333, boots:0x555555 },
-            { shirt:0x808080, pants:0x000080, boots:0x222222 },
-            { shirt:0x008080, pants:0x004040, boots:0xaaaaaa },
-            { shirt:0x5a2e2e, pants:0x3a2e2e, boots:0x555555 },
-            { shirt:0xff5500, pants:0x333333, boots:0x000000 },
-            { shirt:0x00aaff, pants:0x0000aa, boots:0x000000 },
-            { shirt:0x3333ff, pants:0x0000aa, boots:0x000000 },
-            { shirt:0x964B00, pants:0x333333, boots:0x552200 },
-            { shirt:0x228B22, pants:0x8B4513, boots:0x000000 }
-        ];
+        player.add(torch);
+        torch.position.set(0, 2.5, 0);
 
         const npcDefs = [
-            { name:"Village Elder",  pos:[0,0,0],   wander:0, tag:'elder-name',       outfit:npcOutfits[0] },
-            { name:"Fisherman",     pos:[-15,0,-15],wander:6, tag:'fisherman-name',  outfit:npcOutfits[1] },
-            { name:"Sage of the Tides", pos:[10,0,-25], wander:5, tag:'sage-name',   outfit:npcOutfits[2] },
-            { name:"War-Torn Elder", pos:[-20,0,10], wander:4, tag:'war-torn-elder-name', outfit:npcOutfits[3] },
-            { name:"Blacksmith",    pos:[15,0,5],  wander:5, tag:'blacksmith-name', outfit:npcOutfits[4] },
-            { name:"Merchant",      pos:[-10,0,25],wander:7, tag:'merchant-name',    outfit:npcOutfits[5] },
-            { name:"Guard",         pos:[25,0,10], wander:6, tag:'guard-name',      outfit:npcOutfits[6] },
-            { name:"Innkeeper",     pos:[5,0,25],  wander:4, tag:'innkeeper-name',  outfit:npcOutfits[7] },
-            { name:"Farmer",        pos:[-25,0,5], wander:7, tag:'farmer-name',     outfit:npcOutfits[8] }
+            { name:"Village Elder",  pos:[0,0,0],   wander:0, tag:'elder-name',       sprite:'peasant' },
+            { name:"Fisherman",     pos:[-15,0,-15],wander:6, tag:'fisherman-name',  sprite:'peasant' },
+            { name:"Sage of the Tides", pos:[10,0,-25], wander:5, tag:'sage-name',   sprite:'monk' },
+            { name:"War-Torn Elder", pos:[-20,0,10], wander:4, tag:'war-torn-elder-name', sprite:'peasant' },
+            { name:"Blacksmith",    pos:[15,0,5],  wander:5, tag:'blacksmith-name', sprite:'peasant' },
+            { name:"Merchant",      pos:[-10,0,25],wander:7, tag:'merchant-name',    sprite:'peasant' },
+            { name:"Guard",         pos:[25,0,10], wander:6, tag:'guard-name',      sprite:'knight' },
+            { name:"Innkeeper",     pos:[5,0,25],  wander:4, tag:'innkeeper-name',  sprite:'peasant' },
+            { name:"Farmer",        pos:[-25,0,5], wander:7, tag:'farmer-name',     sprite:'peasant' }
         ];
 
         const npcObjects = npcDefs.map(def => {
-            const outfit = def.outfit || npcOutfits[Math.floor(Math.random() * npcOutfits.length)];
-            const npc = createCharacterModel(0xffddbb, outfit.shirt, outfit.pants, outfit.boots);
+            const npc = new SpriteCharacter(SPRITE_SHEETS[def.sprite], { animations: SPRITE_ANIMATIONS });
             npc.position.set(def.pos[0], def.pos[1], def.pos[2]);
             npc.name = def.name;
             npc.userData.tagEl = document.getElementById(def.tag);
             scene.add(npc);
-            if (def.wander) addWanderer(npc, def.wander);
+            if (def.wander) addWanderer(npc, def.wander); else npc.setAnimation('idle');
             return npc;
         });
 
@@ -2143,11 +2034,16 @@
                 w.angle += delta * w.speed;
                 w.obj.position.x = w.center.x + Math.cos(w.angle) * w.radius;
                 w.obj.position.z = w.center.z + Math.sin(w.angle) * w.radius;
-                animateLimbs(w.obj, elapsed * 5 + w.angle);
             });
 
-            if (!gameStarted) { renderer.render(scene, camera); return; }
+            if (!gameStarted) {
+                player.update(delta, camera);
+                npcObjects.forEach(n => n.update(delta, camera));
+                renderer.render(scene, camera);
+                return;
+            }
 
+            let moving = false;
             if (canMove) {
                 const dir = new THREE.Vector3();
                 if (moveForward) dir.z -= 1;
@@ -2157,15 +2053,15 @@
                 if (dir.lengthSq() > 0) {
                     dir.normalize().multiplyScalar(moveSpeed * delta);
                     player.position.add(dir);
-                    animateLimbs(player, elapsed * 5);
+                    player.setAnimation('walk');
+                    moving = true;
                     encounterDistance += dir.length();
                     if (randomEncountersEnabled && encounterDistance > 50 && Math.random() < 0.02) { encounterDistance = 0; triggerRandomEncounter(); }
-                } else {
-                    animateLimbs(player, 0);
                 }
-            } else {
-                animateLimbs(player, 0);
             }
+            if (!moving) player.setAnimation('idle');
+            player.update(delta, camera);
+            npcObjects.forEach(n => n.update(delta, camera));
 
             checkDungeonEntrance();
 


### PR DESCRIPTION
## Summary
- add `SpriteCharacter` class for billboarded sprite animation
- provide placeholder sprite sheets for knight, peasant, and monk
- swap 3D model loading for sprite-based characters and update animation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2951ce5808324bdcc95b1bc30d508