### PR TITLE
fix: resolve duplicate createHut definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1440,12 +1440,12 @@
         fishingVillage.add(sea);
 
         // Simple huts for the fishing village
-        function createHut(x, z) {
+        function createFishingHut(x, z) {
             const hut = createBuilding(4, 3, 4, 0x9b7653, 0x8b4513);
             hut.position.set(x, 0, z);
             return hut;
         }
-        [createHut(-12, 20), createHut(12, 20)].forEach(h => fishingVillage.add(h));
+        [createFishingHut(-12, 20), createFishingHut(12, 20)].forEach(h => fishingVillage.add(h));
 
         // Signpost at the village entrance
         const sign = new THREE.Group();


### PR DESCRIPTION
## Summary
- rename local fishing village hut function to avoid clashing with imported `createHut`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2984d5b588324909ca00e6a529502