### PR TITLE
Add basic service worker for offline caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -2391,5 +2391,12 @@
         });
 
     </script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/service-worker.js');
+            });
+        }
+    </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,39 @@
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const ASSETS = ['/', '/index.html'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== STATIC_CACHE).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  const assetRegex = /\.(?:html|js|css|png|jpg|jpeg|gif|svg)$/;
+  if (assetRegex.test(url.pathname)) {
+    event.respondWith(
+      caches.match(event.request).then(res => {
+        return (
+          res ||
+          fetch(event.request).then(response => {
+            const copy = response.clone();
+            caches.open(STATIC_CACHE).then(cache => cache.put(event.request, copy));
+            return response;
+          })
+        );
+      })
+    );
+  }
+});
+


### PR DESCRIPTION
## Summary
- Add service worker to cache static assets and manage fetch events
- Register service worker in index.html to enable offline caching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c29becc2d08324868321e61187d530