### PR TITLE
Fix service worker path for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2395,7 +2395,7 @@
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/service-worker.js');
+                navigator.serviceWorker.register('service-worker.js');
             });
         }
     </script>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,7 @@
 const CACHE_VERSION = 'v1';
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
-const ASSETS = ['/', '/index.html'];
+const BASE_PATH = self.location.pathname.replace(/service-worker\.js$/, '');
+const ASSETS = [BASE_PATH, `${BASE_PATH}index.html`];
 
 self.addEventListener('install', event => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- Register service worker using a relative path so GitHub Pages can locate it
- Compute base path inside the service worker and cache correct URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2a453667483248c9145eb7b5e5bd0