### PR TITLE
Use primitive NPC models when GLTF is absent

### DIFF
--- a/index.html
+++ b/index.html
@@ -955,8 +955,10 @@
                 modelUrl,
                 gltf => {
                     const model = gltf.scene;
+                    let hasMesh = false;
                     model.traverse(obj => {
                         if (obj.isMesh) {
+                            hasMesh = true;
                             obj.castShadow = true;
                             obj.receiveShadow = true;
                             const name = obj.name.toLowerCase();
@@ -973,13 +975,20 @@
                             obj.material = mat;
                         }
                     });
-                    group.add(model);
+                    if (hasMesh) {
+                        group.add(model);
+                    } else {
+                        const primitive = buildPrimitive();
+                        group.add(primitive);
+                        group.userData = primitive.userData;
+                    }
                 },
                 undefined,
                 error => {
                     console.warn('Failed to load humanoid model, using primitives instead.', error);
                     const primitive = buildPrimitive();
                     group.add(primitive);
+                    group.userData = primitive.userData;
                 }
             );
 


### PR DESCRIPTION
## Summary
- Detect empty NPC glTF models and fall back to primitive geometry
- Preserve arm and leg references for animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b41e4bb8832494ad9cd2b66dba84