### PR TITLE
Handle missing NPC name tags gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -2277,15 +2277,23 @@
         }
 
         function updateNpcNameTags() {
-            if (!canMove) { npcObjects.forEach(n=> n.userData.tagEl.style.display='none'); return; }
+            if (!canMove) {
+                npcObjects.forEach(n => {
+                    const tagEl = n.userData.tagEl;
+                    if (tagEl) tagEl.style.display = 'none';
+                });
+                return;
+            }
             npcObjects.forEach(n => {
+                const tagEl = n.userData.tagEl;
+                if (!tagEl) return;
                 const pos = toScreenPosition(n, camera);
                 if (pos) {
-                    n.userData.tagEl.style.display='block';
-                    n.userData.tagEl.style.left = `${pos.x}px`;
-                    n.userData.tagEl.style.top = `${pos.y - 45}px`;
+                    tagEl.style.display = 'block';
+                    tagEl.style.left = `${pos.x}px`;
+                    tagEl.style.top = `${pos.y - 45}px`;
                 } else {
-                    n.userData.tagEl.style.display='none';
+                    tagEl.style.display = 'none';
                 }
             });
         }


### PR DESCRIPTION
## Summary
- Prevent crashes when NPC tag elements are missing by checking for their presence before manipulating styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2b8376e58832490c43e7a3551fb83