### PR TITLE
Expand village and replace fence with Viking palisade

### DIFF
--- a/assets/sprites/villageStructures.js
+++ b/assets/sprites/villageStructures.js
@@ -1,34 +1,84 @@
 import * as THREE from 'three';
 
-// Utility to create a colored billboard sprite. The sprite will always face the camera
-// and serves as a lightweight stand-in for what used to be fully modeled geometry.
-function createBillboard(color, width, height) {
-  const canvas = document.createElement('canvas');
-  canvas.width = canvas.height = 128;
-  const ctx = canvas.getContext('2d');
-  ctx.fillStyle = '#' + color.toString(16).padStart(6, '0');
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-  const texture = new THREE.CanvasTexture(canvas);
-  const material = new THREE.SpriteMaterial({ map: texture });
-  const sprite = new THREE.Sprite(material);
-  sprite.scale.set(width, height, 1);
-  return sprite;
-}
-
-// Simple billboarded representations of the village structures.
+// Simple geometry-based representations of village structures.
 export function createHut() {
-  return createBillboard(0xF2D6B3, 4, 4);
+  const hut = new THREE.Group();
+
+  const baseHeight = 2;
+  const base = new THREE.Mesh(
+    new THREE.CylinderGeometry(2, 2, baseHeight, 6),
+    new THREE.MeshStandardMaterial({ color: 0x8B4513 })
+  );
+  base.castShadow = true;
+  base.receiveShadow = true;
+  hut.add(base);
+
+  const roofHeight = 1.5;
+  const roof = new THREE.Mesh(
+    new THREE.ConeGeometry(2.2, roofHeight, 6),
+    new THREE.MeshStandardMaterial({ color: 0xCD853F })
+  );
+  roof.position.y = baseHeight / 2 + roofHeight / 2;
+  roof.castShadow = true;
+  hut.add(roof);
+
+  return hut;
 }
 
 export function createFarmRow() {
-  return createBillboard(0xC9E4B4, 8, 2);
+  const row = new THREE.Mesh(
+    new THREE.BoxGeometry(8, 0.2, 2),
+    new THREE.MeshStandardMaterial({ color: 0x228B22 })
+  );
+  row.position.y = 0.1;
+  row.receiveShadow = true;
+  return row;
 }
 
 export function createLordHouse() {
-  return createBillboard(0xF5E0C3, 8, 8);
+  const house = new THREE.Group();
+
+  const baseHeight = 3;
+  const base = new THREE.Mesh(
+    new THREE.BoxGeometry(8, baseHeight, 8),
+    new THREE.MeshStandardMaterial({ color: 0xB5651D })
+  );
+  base.castShadow = true;
+  base.receiveShadow = true;
+  house.add(base);
+
+  const roofHeight = 2.5;
+  const roof = new THREE.Mesh(
+    new THREE.ConeGeometry(6, roofHeight, 4),
+    new THREE.MeshStandardMaterial({ color: 0x8B4513 })
+  );
+  roof.position.y = baseHeight / 2 + roofHeight / 2;
+  roof.castShadow = true;
+  house.add(roof);
+
+  return house;
 }
 
 export function createChurch() {
-  return createBillboard(0xE3E3F7, 6, 10);
+  const church = new THREE.Group();
+
+  const baseHeight = 6;
+  const body = new THREE.Mesh(
+    new THREE.BoxGeometry(6, baseHeight, 4),
+    new THREE.MeshStandardMaterial({ color: 0xD8D8D8 })
+  );
+  body.castShadow = true;
+  body.receiveShadow = true;
+  church.add(body);
+
+  const roofHeight = 3;
+  const roof = new THREE.Mesh(
+    new THREE.ConeGeometry(5, roofHeight, 4),
+    new THREE.MeshStandardMaterial({ color: 0x8B0000 })
+  );
+  roof.position.y = baseHeight / 2 + roofHeight / 2;
+  roof.castShadow = true;
+  church.add(roof);
+
+  return church;
 }

--- a/index.html
+++ b/index.html
@@ -1308,35 +1308,32 @@
         createRoad(0, 0, 40, 4);  // east-west road
         createRoad(0, 0, 4, 40);  // north-south road
 
-        // Perimeter fencing styled as a tall medieval palisade
-        const fenceTexture = new THREE.TextureLoader().load('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEUlEQVR4nGPojtJeEKTLAKEAIBkEXwaID48AAAAASUVORK5CYII=');
-        fenceTexture.wrapS = fenceTexture.wrapT = THREE.RepeatWrapping;
-        fenceTexture.repeat.set(4, 1);
-        const fenceMaterial = new THREE.MeshStandardMaterial({ map: fenceTexture, color: 0x8B5A2B });
+        // Perimeter fencing styled as a Viking palisade barrier
+        const fenceMaterial = new THREE.MeshStandardMaterial({ color: 0x8B5A2B });
         const fenceRadius = 40;
-        const fenceStep = Math.PI / 8;
-        const logHeights = [1.5, 3];
-        for (let angle = 0; angle < Math.PI * 2; angle += fenceStep) {
-            const nextAngle = angle + fenceStep;
-            const postHeight = 4;
-            const post = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.3, postHeight, 8), fenceMaterial);
-            post.position.set(Math.cos(angle) * fenceRadius, postHeight / 2, Math.sin(angle) * fenceRadius);
-            post.castShadow = true; village.add(post);
+        const logHeight = 6;
+        const logSpacing = 1;
+        const logCount = Math.floor(2 * Math.PI * fenceRadius / logSpacing);
+        for (let i = 0; i < logCount; i++) {
+            const angle = (i / logCount) * Math.PI * 2;
+            const x = Math.cos(angle) * fenceRadius;
+            const z = Math.sin(angle) * fenceRadius;
 
-            // create horizontal logs between this post and the next
-            const startPos = new THREE.Vector3(Math.cos(angle) * fenceRadius, 0, Math.sin(angle) * fenceRadius);
-            const endPos = new THREE.Vector3(Math.cos(nextAngle) * fenceRadius, 0, Math.sin(nextAngle) * fenceRadius);
-            const dir = new THREE.Vector3().subVectors(endPos, startPos);
-            const railLength = dir.length();
-            const midPoint = new THREE.Vector3().addVectors(startPos, endPos).multiplyScalar(0.5);
-            const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.normalize());
-            logHeights.forEach(h => {
-                const log = new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0.2, railLength, 8), fenceMaterial);
-                log.position.copy(midPoint);
-                log.position.y = h;
-                log.quaternion.copy(quat);
-                log.castShadow = true; village.add(log);
-            });
+            const log = new THREE.Mesh(
+                new THREE.CylinderGeometry(0.5, 0.6, logHeight, 8),
+                fenceMaterial
+            );
+            log.position.set(x, logHeight / 2, z);
+            log.castShadow = true;
+            village.add(log);
+
+            const tip = new THREE.Mesh(
+                new THREE.ConeGeometry(0.6, 1, 8),
+                fenceMaterial
+            );
+            tip.position.set(x, logHeight + 0.5, z);
+            tip.castShadow = true;
+            village.add(tip);
         }
 
         // Market stalls surrounding a central well
@@ -1373,8 +1370,8 @@
         const farm = new THREE.Mesh(new THREE.PlaneGeometry(10, 10), new THREE.MeshStandardMaterial({ color: 0x8B4513 }));
         farm.rotation.x = -Math.PI / 2; farm.position.set(60, 0, 0); farm.receiveShadow = true; utilityGroup.add(farm);
 
-        // Scale up the entire village
-        village.scale.set(1.5, 1.5, 1.5);
+        // Scale up the entire village to give it a grander presence
+        village.scale.set(2.5, 2.5, 2.5);
 
         // Road leading to the fishing village
         const fishingRoadPoints = [


### PR DESCRIPTION
## Summary
- Replace placeholder sprites with simple 3D models for huts, farm rows, lord's house, and church.
- Surround town with a Viking-style palisade made of sharpened logs.
- Scale up the village for a larger, more imposing settlement.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2bc2691d883248002abb12b5edfa8