### PR TITLE
Improve service worker offline support

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Offline</title>
+</head>
+<body>
+<h1>You are offline</h1>
+<p>Please check your network connection.</p>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,9 +1,15 @@
 const CACHE_VERSION = 'v1';
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const BASE_PATH = self.location.pathname.replace(/service-worker\.js$/, '');
-const ASSETS = [BASE_PATH, `${BASE_PATH}index.html`];
+const ASSETS = [
+  BASE_PATH,
+  `${BASE_PATH}index.html`,
+  `${BASE_PATH}offline.html`,
+  `${BASE_PATH}assets/sprites/villageStructures.js`
+];
 
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(STATIC_CACHE).then(cache => cache.addAll(ASSETS))
   );
@@ -11,27 +17,38 @@ self.addEventListener('install', event => {
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.filter(key => key !== STATIC_CACHE).map(key => caches.delete(key))
+    caches.keys()
+      .then(keys =>
+        Promise.all(
+          keys.filter(key => key !== STATIC_CACHE).map(key => caches.delete(key))
+        )
       )
-    )
+      .then(() => self.clients.claim())
   );
 });
 
 self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(`${BASE_PATH}offline.html`))
+    );
+    return;
+  }
+
   const assetRegex = /\.(?:html|js|css|png|jpg|jpeg|gif|svg)$/;
   if (assetRegex.test(url.pathname)) {
     event.respondWith(
       caches.match(event.request).then(res => {
         return (
           res ||
-          fetch(event.request).then(response => {
-            const copy = response.clone();
-            caches.open(STATIC_CACHE).then(cache => cache.put(event.request, copy));
-            return response;
-          })
+          fetch(event.request)
+            .then(response => {
+              const copy = response.clone();
+              caches.open(STATIC_CACHE).then(cache => cache.put(event.request, copy));
+              return response;
+            })
+            .catch(() => caches.match(`${BASE_PATH}offline.html`))
         );
       })
     );


### PR DESCRIPTION
## Summary
- cache key static assets including sprites and offline page
- ensure new service worker takes control immediately
- serve cached offline page when network requests fail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c3a82edf3c832796e543ec92dcbc75