### PR TITLE
Add unit and integration tests with modular game state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "write-the-realm",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "test": "node --test"
   },

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,36 @@
+export const state = {
+  currentQuestIndex: 0,
+  quests: [],
+  canInteractWith: null,
+  isCombatActive: false,
+};
+
+export function resetState() {
+  state.currentQuestIndex = 0;
+  state.quests = [];
+  state.canInteractWith = null;
+  state.isCombatActive = false;
+}
+
+export function addQuest(quest) {
+  state.quests.push({ ...quest, isComplete: false });
+}
+
+export function getCurrentQuest() {
+  return state.quests[state.currentQuestIndex];
+}
+
+export function completeCurrentQuest() {
+  const quest = getCurrentQuest();
+  if (quest) {
+    quest.isComplete = true;
+  }
+}
+
+export function advanceQuest() {
+  if (state.currentQuestIndex < state.quests.length - 1) {
+    state.currentQuestIndex++;
+    return true;
+  }
+  return false;
+}

--- a/test/apiProxy.test.js
+++ b/test/apiProxy.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import geminiHandler from '../api/gemini.js';
+import ttsHandler from '../api/gemini-tts.js';
+
+function createResponse() {
+  return {
+    statusCode: 0,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; }
+  };
+}
+
+test('gemini proxy forwards request body and returns response', async (t) => {
+  process.env.GEMINI_API_KEY = 'key';
+  const mock = t.mock.method(globalThis, 'fetch', async (url, options) => {
+    assert.ok(url.includes('gemini-2.5-flash-preview-05-20'));
+    assert.deepEqual(options.method, 'POST');
+    assert.deepEqual(JSON.parse(options.body), { hello: 'world' });
+    return {
+      ok: true,
+      json: async () => ({ data: 'response' })
+    };
+  });
+
+  const req = { method: 'POST', body: { hello: 'world' } };
+  const res = createResponse();
+
+  await geminiHandler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { data: 'response' });
+  assert.equal(mock.mock.calls.length, 1);
+});
+
+test('gemini tts proxy forwards request body and returns response', async (t) => {
+  process.env.GEMINI_API_KEY = 'key';
+  const mock = t.mock.method(globalThis, 'fetch', async (url, options) => {
+    assert.ok(url.includes('gemini-2.5-flash-preview-tts'));
+    return {
+      ok: true,
+      json: async () => ({ audio: 'base64data' })
+    };
+  });
+
+  const req = { method: 'POST', body: { text: 'hello' } };
+  const res = createResponse();
+
+  await ttsHandler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { audio: 'base64data' });
+  assert.equal(mock.mock.calls.length, 1);
+});

--- a/test/placeholder.test.js
+++ b/test/placeholder.test.js
@@ -1,6 +1,0 @@
-const test = require('node:test');
-const assert = require('node:assert/strict');
-
-test('placeholder test passes', () => {
-  assert.strictEqual(1 + 1, 2);
-});

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  state,
+  resetState,
+  addQuest,
+  getCurrentQuest,
+  completeCurrentQuest,
+  advanceQuest
+} from '../src/state.js';
+
+// Ensure each test starts with a clean state
+function setup() {
+  resetState();
+}
+
+test('adding and retrieving quests works', () => {
+  setup();
+  addQuest({ id: 'q1', title: 'First Quest' });
+  addQuest({ id: 'q2', title: 'Second Quest' });
+  assert.equal(state.quests.length, 2);
+  assert.deepEqual(getCurrentQuest().id, 'q1');
+});
+
+test('completing current quest sets flag', () => {
+  setup();
+  addQuest({ id: 'q1', title: 'Quest' });
+  completeCurrentQuest();
+  assert.ok(getCurrentQuest().isComplete);
+});
+
+test('advanceQuest moves to next quest when possible', () => {
+  setup();
+  addQuest({ id: 'q1' });
+  addQuest({ id: 'q2' });
+  assert.equal(state.currentQuestIndex, 0);
+  const advanced = advanceQuest();
+  assert.ok(advanced);
+  assert.equal(state.currentQuestIndex, 1);
+  // Cannot advance past last quest
+  assert.equal(advanceQuest(), false);
+  assert.equal(state.currentQuestIndex, 1);
+});
+


### PR DESCRIPTION
## Summary
- Add `src/state.js` for modular game state handling
- Replace placeholder test with state unit tests
- Add integration tests for Gemini API proxies using mocked fetch
- Configure project for ES modules and run tests via `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3a8ea67cc8327bcc0d407fdd39b11