### PR TITLE
feat: centralize game state with setters

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,27 +530,16 @@
     <script type="module">
         import * as THREE from 'three';
         // Billboarded sprites representing village structures
-        import { createHut, createFarmRow, createLordHouse, createChurch } from './assets/sprites/villageStructures.js';
+                import { getCharacterData, setCharacterData, getPlayerStats, setPlayerStats, getGameState, setGameState } from './state.js';
 
         // --- GEMINI API SETUP ---
         const LLM_API_URL = '/gemini';
         const TTS_API_URL = '/gemini-tts';
 
         // --- GAME STATE & CHARACTER DATA ---
-        let characterData = { type: null, domain: null, customName: "" };
-
-        let playerStats = {
-            level: 1,
-            xp: 0,
-            xpToNextLevel: 100,
-            baseHealth: 100,
-            baseDamage: 10,
-            journal: [],
-            achievements: {},
-            collectedFragments: 0,
-            inventory: {}, // map id -> { owned, equipped }
-            equipmentSlots: { weapon: null, armor: null, trinket: null }
-        };
+        let characterData = getCharacterData();
+        let playerStats = getPlayerStats();
+        let gameState = getGameState();
 
         // Movement
         let baseMoveSpeed = 8.0;
@@ -1462,15 +1451,6 @@
         const clock = new THREE.Clock();
         let canMove = true; let gameStarted = false;
         const randomEncountersEnabled = false;
-        const gameState = {
-            currentQuestIndex: 0,
-            quests: [
-                { id: "AWAKENING", type: "writing", title: "A Stranger's Arrival", objective: "Introduce yourself to the Village Elder.", writingPrompt: "The Village Elder studies you. 'Who are you, and why have you come?' Describe your hero (appearance, personality, and a clear goal).", isComplete: false, npc: "Village Elder", rewardXP: 100, prewriteCleared:false },
-                { id: "RISING_ACTION", type: "writing", title: "The Spreading Sickness", objective: "Find the Fisherman to learn about the growing blight.", writingPrompt: "The Fisherman points to the horizon. 'It started small,' he says, 'but now... it breathes.' Describe the monstrous slick of pollution using strong doing words and sensory detail.", isComplete: false, npc: "Fisherman", rewardXP: 150, prewriteCleared:false }
-            ],
-            canInteractWith: null,
-            isCombatActive: false
-        };
 
         // --- COMBAT STATE ---
         let combatState = { playerHP: 100, enemyHP: 100, playerDamage: 10, enemyDamage: 5, isPlayerTurn: true, useSpecialMove: false };
@@ -2326,10 +2306,12 @@
                 const savedJSON = localStorage.getItem('narrativeQuestSaveData');
                 if (savedJSON) {
                     const saved = JSON.parse(savedJSON);
-                    characterData = saved.characterData;
-                    playerStats = saved.playerStats;
-                    gameState.quests = saved.gameState.quests;
-                    gameState.currentQuestIndex = saved.gameState.currentQuestIndex;
+                    setCharacterData(saved.characterData);
+                    characterData = getCharacterData();
+                    setPlayerStats(saved.playerStats);
+                    playerStats = getPlayerStats();
+                    setGameState(saved.gameState);
+                    gameState = getGameState();
                     if (saved.collectedFragments) saved.collectedFragments.forEach((c,i)=>{ if (memoryFragments[i]) { memoryFragments[i].collected = c; if (c) memoryFragmentMeshes[i].visible = false; } });
                     // Re-apply gear stats
                     applyGearStats();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "write-the-realm",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "test": "node --test"
   },

--- a/state.js
+++ b/state.js
@@ -1,0 +1,48 @@
+let characterData = { type: null, domain: null, customName: "" };
+
+let playerStats = {
+    level: 1,
+    xp: 0,
+    xpToNextLevel: 100,
+    baseHealth: 100,
+    baseDamage: 10,
+    journal: [],
+    achievements: {},
+    collectedFragments: 0,
+    inventory: {},
+    equipmentSlots: { weapon: null, armor: null, trinket: null }
+};
+
+let gameState = {
+    currentQuestIndex: 0,
+    quests: [
+        { id: "AWAKENING", type: "writing", title: "A Stranger's Arrival", objective: "Introduce yourself to the Village Elder.", writingPrompt: "The Village Elder studies you. 'Who are you, and why have you come?' Describe your hero (appearance, personality, and a clear goal).", isComplete: false, npc: "Village Elder", rewardXP: 100, prewriteCleared:false },
+        { id: "RISING_ACTION", type: "writing", title: "The Spreading Sickness", objective: "Find the Fisherman to learn about the growing blight.", writingPrompt: "The Fisherman points to the horizon. 'It started small,' he says, 'but now... it breathes.' Describe the monstrous slick of pollution using strong doing words and sensory detail.", isComplete: false, npc: "Fisherman", rewardXP: 150, prewriteCleared:false }
+    ],
+    canInteractWith: null,
+    isCombatActive: false
+};
+
+export function getCharacterData() {
+    return characterData;
+}
+
+export function setCharacterData(data) {
+    characterData = data;
+}
+
+export function getPlayerStats() {
+    return playerStats;
+}
+
+export function setPlayerStats(stats) {
+    playerStats = stats;
+}
+
+export function getGameState() {
+    return gameState;
+}
+
+export function setGameState(state) {
+    gameState = state;
+}

--- a/test/placeholder.test.js
+++ b/test/placeholder.test.js
@@ -1,5 +1,5 @@
-const test = require('node:test');
-const assert = require('node:assert/strict');
+import test from 'node:test';
+import assert from 'node:assert/strict';
 
 test('placeholder test passes', () => {
   assert.strictEqual(1 + 1, 2);

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getCharacterData,
+  setCharacterData,
+  getPlayerStats,
+  setPlayerStats,
+  getGameState,
+  setGameState
+} from '../state.js';
+
+test('setCharacterData updates state', () => {
+  const data = { type: 'mage', domain: 'fire', customName: 'Fira' };
+  setCharacterData(data);
+  assert.deepEqual(getCharacterData(), data);
+});
+
+test('setPlayerStats updates state', () => {
+  const stats = {
+    level: 2,
+    xp: 10,
+    xpToNextLevel: 120,
+    baseHealth: 110,
+    baseDamage: 12,
+    journal: [],
+    achievements: {},
+    collectedFragments: 1,
+    inventory: {},
+    equipmentSlots: { weapon: null, armor: null, trinket: null }
+  };
+  setPlayerStats(stats);
+  assert.deepEqual(getPlayerStats(), stats);
+});
+
+test('setGameState updates state', () => {
+  const state = {
+    currentQuestIndex: 1,
+    quests: [],
+    canInteractWith: null,
+    isCombatActive: true
+  };
+  setGameState(state);
+  assert.deepEqual(getGameState(), state);
+});


### PR DESCRIPTION
## Summary
- move character, player, and game state to dedicated module with getters and setters
- update game script to use shared state module
- add unit tests for state updates and switch project to ESM

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3a929ffe08327a6f9d341457e9f23