### PR TITLE
Fix missing lighting and hidden NPC names

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
         .npc-name {
             position: absolute; background: rgba(0, 0, 0, 0.5); color: white; padding: 4px 8px; border-radius: 4px;
             font-size: 0.8rem; text-align: center; transform: translate(-50%, -50%); pointer-events: none;
-            white-space: nowrap; display: none;
+            white-space: nowrap;
         }
         #message-box { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
             background-color: var(--panel-bg); color: #3a2d21; padding: 20px; border: 2px solid var(--panel-border); border-radius: 8px;

--- a/src/render.js
+++ b/src/render.js
@@ -20,6 +20,16 @@ export function initRenderer(container = document.body) {
   renderer.setSize(window.innerWidth, window.innerHeight);
   container.appendChild(renderer.domElement);
   camera.position.z = 5;
+
+  // Add simple lighting so that meshes using standard materials are visible
+  // when the scene initializes. Without at least an ambient light the imported
+  // models render completely black, which made characters appear to be missing.
+  const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+  scene.add(ambient);
+
+  const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+  directional.position.set(5, 10, 7.5);
+  scene.add(directional);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add ambient and directional lights to initRenderer so standard-material models become visible
- remove display:none from NPC name style so character names show

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c3d5dde1688327817f3ad0cc5c5515