### PR TITLE
Ensure NPC names render in UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,9 +244,17 @@
         .health-bar { background: linear-gradient(90deg, #d9534f, #f7d58b); height: 10px; border-radius: 9999px; transition: width 0.5s ease-in-out; }
         .health-bar.player { background: linear-gradient(90deg, #5cb85c, #90ee90); }
         .npc-name {
-            position: absolute; background: rgba(0, 0, 0, 0.5); color: white; padding: 4px 8px; border-radius: 4px;
-            font-size: 0.8rem; text-align: center; transform: translate(-50%, -50%); pointer-events: none;
+            position: absolute;
+            background: rgba(0, 0, 0, 0.5);
+            color: white;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            text-align: center;
+            transform: translate(-50%, -50%);
+            pointer-events: none;
             white-space: nowrap;
+            display: block;
         }
         #message-box { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
             background-color: var(--panel-bg); color: #3a2d21; padding: 20px; border: 2px solid var(--panel-border); border-radius: 8px;


### PR DESCRIPTION
## Summary
- Ensure NPC name overlays are visible by setting `.npc-name` to `display: block`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3d5dde1688327817f3ad0cc5c5515