### PR TITLE
Enable Forge New Legend button to open character creation

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -13,5 +13,14 @@ export function hidePanel(panel) {
 }
 
 export function initUI() {
-  // Placeholder for hooking up event listeners to UI elements.
+  const startModal = document.getElementById('start-modal');
+  const characterCreator = document.getElementById('character-creator');
+  const newGameBtn = document.getElementById('new-game-btn');
+
+  if (newGameBtn) {
+    newGameBtn.addEventListener('click', () => {
+      hidePanel(startModal);
+      showPanel(characterCreator);
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Add event handler that hides the start modal and displays the character creator when clicking **Forge New Legend**

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3f991d2d48327ac5cb66f47847473