### PR TITLE
Handle missing localStorage gracefully

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -10,15 +10,29 @@ export const gameState = {
   isCombatActive: false,
 };
 
+// Key used for localStorage persistence
+const STORAGE_KEY = 'gameState';
+
+// Detect whether localStorage is available (e.g., in a browser environment)
+function hasStorage() {
+  return typeof localStorage !== 'undefined';
+}
+
 /**
  * Persist the provided state object (defaults to the module's gameState) to
  * localStorage.
  */
 export function saveGame(state = gameState) {
+  if (!hasStorage()) {
+    console.error('localStorage is unavailable; cannot save game');
+    return false;
+  }
   try {
-    localStorage.setItem('gameState', JSON.stringify(state));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    return true;
   } catch (err) {
     console.error('Failed to save game', err);
+    return false;
   }
 }
 
@@ -27,8 +41,12 @@ export function saveGame(state = gameState) {
  * state exists.
  */
 export function loadGame() {
+  if (!hasStorage()) {
+    console.error('localStorage is unavailable; cannot load game');
+    return null;
+  }
   try {
-    const data = localStorage.getItem('gameState');
+    const data = localStorage.getItem(STORAGE_KEY);
     return data ? JSON.parse(data) : null;
   } catch (err) {
     console.error('Failed to load game', err);
@@ -40,5 +58,8 @@ export function loadGame() {
  * Convenience helper to check whether a saved game is present in storage.
  */
 export function checkForSavedGame() {
-  return !!localStorage.getItem('gameState');
+  if (!hasStorage()) {
+    return false;
+  }
+  return !!localStorage.getItem(STORAGE_KEY);
 }

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { saveGame, loadGame, checkForSavedGame } = require('../src/state.js');
+
+// When localStorage is unavailable (e.g., in Node), the state module should
+// surface errors via return values rather than throwing.
+
+test('saveGame returns false when storage is unavailable', () => {
+  assert.strictEqual(saveGame(), false);
+});
+
+test('loadGame returns null when storage is unavailable', () => {
+  assert.strictEqual(loadGame(), null);
+});
+
+test('checkForSavedGame returns false when storage is unavailable', () => {
+  assert.strictEqual(checkForSavedGame(), false);
+});


### PR DESCRIPTION
## Summary
- guard storage helpers when `localStorage` is unavailable
- ensure functions return safe fallbacks
- add unit tests for storage missing scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3fda0c4ac8327b7f17bfcd0e953a5