### PR TITLE
feat: show UI on load; remove placeholder cube

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -3,7 +3,6 @@ import * as THREE from 'three';
 let scene;
 let camera;
 let renderer;
-let cube;
 
 function handleResize() {
   const width = window.innerWidth;
@@ -33,14 +32,6 @@ export function initRenderer(container = document.body) {
   container.appendChild(renderer.domElement);
   camera.position.z = 5;
 
-  // Display a simple cube so the player doesn't see a blank screen when the
-  // game boots. This placeholder geometry can be replaced with actual game
-  // assets later.
-  const geometry = new THREE.BoxGeometry();
-  const material = new THREE.MeshStandardMaterial({ color: 0x00796b });
-  cube = new THREE.Mesh(geometry, material);
-  scene.add(cube);
-
   // Add simple lighting so that meshes using standard materials are visible
   // when the scene initializes. Without at least an ambient light the imported
   // models render completely black, which made characters appear to be missing.
@@ -59,9 +50,5 @@ export function initRenderer(container = document.body) {
  */
 export function animate() {
   requestAnimationFrame(animate);
-  if (cube) {
-    cube.rotation.x += 0.01;
-    cube.rotation.y += 0.01;
-  }
   renderer.render(scene, camera);
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -58,4 +58,6 @@ export function initUI() {
       if (uiContainer) uiContainer.style.visibility = 'visible';
     });
   }
+
+  if (uiContainer) uiContainer.style.visibility = 'visible';
 }


### PR DESCRIPTION
## Summary
- Ensure HUD is visible immediately when the app loads
- Remove placeholder cube rendering and its animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c4987919a883279ebaa2527726f665