### PR TITLE
Add basic keyboard camera controls

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -1,0 +1,49 @@
+// Helper module to manage keyboard controls for camera movement.
+// Provides initControls to register key handlers and updateControls
+// to move the camera each frame based on pressed keys.
+
+let camera;
+const keyState = {
+  w: false,
+  a: false,
+  s: false,
+  d: false,
+  e: false,
+};
+let movementSpeed = 5;
+
+function onKeyDown(event) {
+  const key = event.key.toLowerCase();
+  if (keyState.hasOwnProperty(key)) {
+    keyState[key] = true;
+    event.preventDefault();
+  }
+}
+
+function onKeyUp(event) {
+  const key = event.key.toLowerCase();
+  if (keyState.hasOwnProperty(key)) {
+    keyState[key] = false;
+    event.preventDefault();
+  }
+}
+
+export function initControls(cam, speed = 5) {
+  camera = cam;
+  movementSpeed = speed;
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+}
+
+export function updateControls(delta) {
+  if (!camera) return;
+  const distance = movementSpeed * delta;
+  if (keyState.w) camera.position.z -= distance;
+  if (keyState.s) camera.position.z += distance;
+  if (keyState.a) camera.position.x -= distance;
+  if (keyState.d) camera.position.x += distance;
+  // Placeholder for interact key 'E'
+  if (keyState.e) {
+    // Future interaction logic can be added here
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,15 +1,28 @@
 import { initRenderer, animate } from './render.js';
+import { initControls, updateControls } from './controls.js';
 import { initUI } from './ui.js';
 import { gameState, saveGame, loadGame, checkForSavedGame } from './state.js';
+
+let lastFrame = 0;
+
+function gameLoop(time) {
+  const delta = (time - lastFrame) / 1000;
+  lastFrame = time;
+  updateControls(delta);
+  requestAnimationFrame(gameLoop);
+}
 
 /**
  * Entry point for the application. Initialises renderer, UI bindings, and
  * kicks off the animation loop.
  */
 export function startGame() {
-  initRenderer();
+  const { camera } = initRenderer();
+  initControls(camera);
   initUI();
   animate();
+  lastFrame = performance.now();
+  requestAnimationFrame(gameLoop);
 }
 
 // Wait for the DOM to be fully loaded before starting the game.

--- a/src/render.js
+++ b/src/render.js
@@ -43,6 +43,7 @@ export function initRenderer(container = document.body) {
   scene.add(directional);
 
   window.addEventListener('resize', handleResize);
+  return { scene, camera, renderer };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Expose renderer and camera from `initRenderer` for external control helpers
- Implement `initControls` and `updateControls` to track WASD/E keys and move the camera
- Integrate control loop into `main.js` to update camera each animation frame

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c5370b3d5c8327ab3862f152fb3139