### PR TITLE
Add quest and combat state helpers

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -13,6 +13,37 @@ export const gameState = {
 };
 
 /**
+ * Update the active quest. Accepts either a quest object to append to the
+ * quest list or a numeric index to switch to an existing quest. The updated
+ * state is immediately persisted.
+ */
+export function updateQuestProgress(quest) {
+  if (typeof quest === 'object' && quest !== null) {
+    gameState.quests.push(quest);
+    gameState.currentQuestIndex = gameState.quests.length - 1;
+  } else if (typeof quest === 'number') {
+    gameState.currentQuestIndex = quest;
+  }
+  saveGame();
+}
+
+/**
+ * Toggle combat status and persist the change.
+ */
+export function updateCombatStatus(active) {
+  gameState.isCombatActive = !!active;
+  saveGame();
+}
+
+/**
+ * Register which target the player can interact with and persist the change.
+ */
+export function updateInteractableTarget(target) {
+  gameState.canInteractWith = target;
+  saveGame();
+}
+
+/**
  * Persist the provided state object (defaults to the module's gameState) to
  * localStorage.
  */

--- a/src/state.js
+++ b/src/state.js
@@ -21,8 +21,14 @@ export function updateQuestProgress(quest) {
   if (typeof quest === 'object' && quest !== null) {
     gameState.quests.push(quest);
     gameState.currentQuestIndex = gameState.quests.length - 1;
-  } else if (typeof quest === 'number') {
+  } else if (
+    typeof quest === 'number' &&
+    quest >= 0 &&
+    quest < gameState.quests.length
+  ) {
     gameState.currentQuestIndex = quest;
+  } else {
+    return; // ignore invalid input
   }
   saveGame();
 }
@@ -31,16 +37,21 @@ export function updateQuestProgress(quest) {
  * Toggle combat status and persist the change.
  */
 export function updateCombatStatus(active) {
-  gameState.isCombatActive = !!active;
-  saveGame();
+  const normalized = !!active;
+  if (gameState.isCombatActive !== normalized) {
+    gameState.isCombatActive = normalized;
+    saveGame();
+  }
 }
 
 /**
  * Register which target the player can interact with and persist the change.
  */
 export function updateInteractableTarget(target) {
-  gameState.canInteractWith = target;
-  saveGame();
+  if (gameState.canInteractWith !== target) {
+    gameState.canInteractWith = target;
+    saveGame();
+  }
 }
 
 /**

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,7 +4,15 @@
  * allows the rendering logic to remain focused on Three.js operations.
  */
 
-import { gameState, saveGame, loadGame, checkForSavedGame } from './state.js';
+import {
+  gameState,
+  saveGame,
+  loadGame,
+  checkForSavedGame,
+  updateQuestProgress,
+  updateCombatStatus,
+  updateInteractableTarget,
+} from './state.js';
 
 export function showPanel(panel) {
   if (panel) panel.style.display = 'block';
@@ -25,6 +33,10 @@ export function initUI() {
   const guardianTypeOptions = document.querySelectorAll('#guardian-type-options .creator-option');
   const guardianDomainOptions = document.querySelectorAll('#guardian-domain-options .creator-option');
   const customGuardianInput = document.getElementById('custom-guardian-input');
+  const questTitle = document.getElementById('quest-title');
+  const questObjective = document.getElementById('quest-objective');
+  const dialogueText = document.getElementById('dialogue-text');
+  const dialogueButton = document.getElementById('dialogue-button');
 
   let selectedGuardianType = '';
   let selectedDomain = '';
@@ -78,6 +90,25 @@ export function initUI() {
 
   if (saveGameBtn) {
     saveGameBtn.addEventListener('click', () => saveGame());
+  }
+
+  if (dialogueButton) {
+    // Player can initially interact with the Village Elder.
+    updateInteractableTarget('Village Elder');
+    dialogueButton.addEventListener('click', () => {
+      const quest = {
+        title: 'Cleanse the River',
+        objective: 'Drive out the corruption poisoning the waters.',
+      };
+      updateQuestProgress(quest);
+      updateInteractableTarget(null);
+      updateCombatStatus(false);
+      if (questTitle) questTitle.textContent = quest.title;
+      if (questObjective) questObjective.textContent = quest.objective;
+      if (dialogueText) dialogueText.textContent =
+        'Thank you, hero! Return once the river runs clear.';
+      dialogueButton.disabled = true;
+    });
   }
 
   if (uiContainer) uiContainer.style.visibility = 'visible';

--- a/src/ui.js
+++ b/src/ui.js
@@ -41,6 +41,17 @@ export function initUI() {
   let selectedGuardianType = '';
   let selectedDomain = '';
 
+  function refreshQuestUI() {
+    const quest = gameState.quests[gameState.currentQuestIndex];
+    if (questTitle) questTitle.textContent = quest ? quest.title : '';
+    if (questObjective) questObjective.textContent = quest ? quest.objective : '';
+    if (dialogueButton) dialogueButton.disabled = !gameState.canInteractWith;
+    if (dialogueText && !gameState.canInteractWith && quest) {
+      dialogueText.textContent =
+        'Thank you, hero! Return once the river runs clear.';
+    }
+  }
+
   if (newGameBtn) {
     newGameBtn.addEventListener('click', () => {
       hidePanel(startModal);
@@ -54,6 +65,7 @@ export function initUI() {
       const loaded = loadGame();
       if (loaded) Object.assign(gameState, loaded);
       hidePanel(startModal);
+      refreshQuestUI();
       if (uiContainer) uiContainer.style.visibility = 'visible';
     });
   }
@@ -95,6 +107,7 @@ export function initUI() {
   if (dialogueButton) {
     // Player can initially interact with the Village Elder.
     updateInteractableTarget('Village Elder');
+    refreshQuestUI();
     dialogueButton.addEventListener('click', () => {
       const quest = {
         title: 'Cleanse the River',
@@ -103,11 +116,11 @@ export function initUI() {
       updateQuestProgress(quest);
       updateInteractableTarget(null);
       updateCombatStatus(false);
-      if (questTitle) questTitle.textContent = quest.title;
-      if (questObjective) questObjective.textContent = quest.objective;
-      if (dialogueText) dialogueText.textContent =
-        'Thank you, hero! Return once the river runs clear.';
-      dialogueButton.disabled = true;
+      if (dialogueText) {
+        dialogueText.textContent =
+          'Thank you, hero! Return once the river runs clear.';
+      }
+      refreshQuestUI();
     });
   }
 

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -69,9 +69,15 @@ test('state persistence', async (t) => {
     assert.strictEqual(stateModule.checkForSavedGame(), false);
   });
 
-  await t.test('state helpers update quest and combat information', () => {
-    const { gameState, updateQuestProgress, updateCombatStatus, updateInteractableTarget } = stateModule;
-    global.localStorage = createMockLocalStorage();
+  await t.test('state helpers update and persist quest and combat information', () => {
+    const {
+      gameState,
+      updateQuestProgress,
+      updateCombatStatus,
+      updateInteractableTarget,
+    } = stateModule;
+    const mock = createMockLocalStorage();
+    global.localStorage = mock;
 
     // reset state
     gameState.currentQuestIndex = 0;
@@ -79,15 +85,26 @@ test('state persistence', async (t) => {
     gameState.isCombatActive = false;
     gameState.canInteractWith = null;
 
-    updateQuestProgress({ title: 'test quest', objective: 'do things' });
-    assert.deepEqual(gameState.quests[0], { title: 'test quest', objective: 'do things' });
+    updateQuestProgress({ title: 'quest1', objective: 'do things' });
+    assert.deepEqual(gameState.quests[0], { title: 'quest1', objective: 'do things' });
     assert.strictEqual(gameState.currentQuestIndex, 0);
+    assert.equal(mock.getItem('gameState'), JSON.stringify(gameState));
+
+    updateQuestProgress({ title: 'quest2' });
+    assert.strictEqual(gameState.currentQuestIndex, 1);
+    assert.equal(mock.getItem('gameState'), JSON.stringify(gameState));
+
+    updateQuestProgress(0);
+    assert.strictEqual(gameState.currentQuestIndex, 0);
+    assert.equal(mock.getItem('gameState'), JSON.stringify(gameState));
 
     updateCombatStatus(true);
     assert.strictEqual(gameState.isCombatActive, true);
+    assert.equal(mock.getItem('gameState'), JSON.stringify(gameState));
 
     updateInteractableTarget('merchant');
     assert.strictEqual(gameState.canInteractWith, 'merchant');
+    assert.equal(mock.getItem('gameState'), JSON.stringify(gameState));
   });
 
   delete global.localStorage;


### PR DESCRIPTION
## Summary
- add helpers to track quest progress, combat state and interactables
- update UI to record quest acceptance in game state and dialogue
- expand state tests for quests and combat persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c541679acc8327883fafddb70a850a