### PR TITLE
Add interactive NPCs and expand village layout

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,8 @@ const ASSETS = [
   `${BASE_PATH}index.html`,
   `${BASE_PATH}offline.html`,
   `${BASE_PATH}assets/styles/main.css`,
-  `${BASE_PATH}assets/sprites/villageStructures.js`
+  `${BASE_PATH}assets/sprites/villageStructures.js`,
+  `${BASE_PATH}src/npcs.js`
 ];
 
 self.addEventListener('install', event => {

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,9 +1,13 @@
 /**
- * Keyboard helpers to move the active camera with basic WASD/E controls.
- * W/A/S/D move along the X/Z axes while E raises the camera on the Y axis.
+ * Keyboard helpers to move the active camera with basic WASD controls and
+ * handle simple NPC interactions.
  */
+import { gameState } from './state.js';
+
 const keys = {};
 let camera;
+let npcs = [];
+const interactPrompt = document.getElementById('interact-prompt');
 // Increased speed for more responsive keyboard navigation around the scene.
 const SPEED = 0.5;
 
@@ -24,6 +28,10 @@ export function initControls(targetCamera) {
   window.addEventListener('keyup', onKeyUp);
 }
 
+export function registerNPCs(list) {
+  npcs = list;
+}
+
 /**
  * Update the camera's position based on currently pressed keys.
  */
@@ -34,5 +42,32 @@ export function updateControls() {
   if (keys['s']) camera.position.z += SPEED;
   if (keys['a']) camera.position.x -= SPEED;
   if (keys['d']) camera.position.x += SPEED;
-  if (keys['e']) camera.position.y += SPEED;
+
+  const dialogueBox = document.getElementById('dialogue-box');
+  const dialogueVisible = dialogueBox && dialogueBox.style.display === 'block';
+  if (dialogueVisible) {
+    if (interactPrompt) interactPrompt.style.display = 'none';
+    return;
+  }
+
+  let target = null;
+  for (const npc of npcs) {
+    const dist = camera.position.distanceTo(npc.mesh.position);
+    if (dist < 2) {
+      target = npc;
+      break;
+    }
+  }
+
+  if (target) {
+    gameState.canInteractWith = target;
+    if (interactPrompt) interactPrompt.style.display = 'block';
+    if (keys['e']) {
+      target.triggerDialogue();
+      keys['e'] = false;
+    }
+  } else {
+    gameState.canInteractWith = null;
+    if (interactPrompt) interactPrompt.style.display = 'none';
+  }
 }

--- a/src/npcs.js
+++ b/src/npcs.js
@@ -1,0 +1,68 @@
+import * as THREE from 'three';
+import { showDialogue } from './ui.js';
+
+function createNPC(name, color, dialogue, quest) {
+  const group = new THREE.Group();
+
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.5, 0.5, 2, 8),
+    new THREE.MeshStandardMaterial({ color })
+  );
+  body.castShadow = true;
+  body.receiveShadow = true;
+  group.add(body);
+
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.5, 16, 16),
+    new THREE.MeshStandardMaterial({ color: 0xffe0bd })
+  );
+  head.position.y = 1.25;
+  head.castShadow = true;
+  group.add(head);
+
+  return {
+    name,
+    mesh: group,
+    dialogue,
+    quest,
+    triggerDialogue() {
+      showDialogue({ name, dialogue, quest });
+    },
+  };
+}
+
+export function createVillageElder() {
+  return createNPC(
+    'Village Elder',
+    0x8b4513,
+    'Our village needs your help. Seek the ancient relic in the forest.',
+    {
+      title: 'The Elder\'s Request',
+      objective: 'Retrieve the relic from the forest',
+    }
+  );
+}
+
+export function createFisherman() {
+  return createNPC(
+    'Fisherman',
+    0x1e90ff,
+    'The tides behave strangely. Investigate the shoreline for me.',
+    {
+      title: 'Strange Tides',
+      objective: 'Investigate the shoreline for anomalies',
+    }
+  );
+}
+
+export function createSageOfTheTides() {
+  return createNPC(
+    'Sage of the Tides',
+    0x228b22,
+    'Bring me a pearl so I may divine the future.',
+    {
+      title: 'Wisdom of the Tides',
+      objective: 'Bring a pearl to the Sage',
+    }
+  );
+}

--- a/src/render.js
+++ b/src/render.js
@@ -5,6 +5,12 @@ import {
   createLordHouse,
   createChurch,
 } from '../assets/sprites/villageStructures.js';
+import { registerNPCs } from './controls.js';
+import {
+  createVillageElder,
+  createFisherman,
+  createSageOfTheTides,
+} from './npcs.js';
 
 export let scene;
 export let camera;
@@ -72,21 +78,54 @@ export function populateVillage(targetScene = scene) {
   ground.receiveShadow = true;
   targetScene.add(ground);
 
-  const hut = createHut();
-  hut.position.set(-5, 1, -2);
-  targetScene.add(hut);
+  // Structures
+  const hut1 = createHut();
+  hut1.position.set(-5, 1, -2);
+  targetScene.add(hut1);
 
-  const farm = createFarmRow();
-  farm.position.set(0, 0, -5);
-  targetScene.add(farm);
+  const hut2 = createHut();
+  hut2.position.set(8, 1, 4);
+  targetScene.add(hut2);
 
-  const house = createLordHouse();
-  house.position.set(5, 1.5, -2);
-  house.rotation.y = Math.PI / 4;
-  targetScene.add(house);
+  const hut3 = createHut();
+  hut3.position.set(-10, 1, 3);
+  targetScene.add(hut3);
+
+  const farm1 = createFarmRow();
+  farm1.position.set(-2, 0, -8);
+  targetScene.add(farm1);
+
+  const farm2 = createFarmRow();
+  farm2.position.set(5, 0, -9);
+  targetScene.add(farm2);
+
+  const house1 = createLordHouse();
+  house1.position.set(5, 1.5, -2);
+  house1.rotation.y = Math.PI / 4;
+  targetScene.add(house1);
+
+  const house2 = createLordHouse();
+  house2.position.set(-6, 1.5, 6);
+  house2.rotation.y = -Math.PI / 6;
+  targetScene.add(house2);
 
   const church = createChurch();
   church.position.set(-8, 3, -2);
   church.rotation.y = -Math.PI / 2;
   targetScene.add(church);
+
+  // NPCs
+  const elder = createVillageElder();
+  elder.mesh.position.set(-8, 1, -4);
+  targetScene.add(elder.mesh);
+
+  const fisherman = createFisherman();
+  fisherman.mesh.position.set(2, 1, -6);
+  targetScene.add(fisherman.mesh);
+
+  const sage = createSageOfTheTides();
+  sage.mesh.position.set(0, 1, 4);
+  targetScene.add(sage.mesh);
+
+  registerNPCs([elder, fisherman, sage]);
 }

--- a/src/state.js
+++ b/src/state.js
@@ -12,6 +12,7 @@ export const gameState = {
   selectedDomain: '',
   journalEntries: [],
   inventory: [],
+  activeQuest: null,
 };
 
 /**

--- a/src/ui.js
+++ b/src/ui.js
@@ -14,6 +14,28 @@ export function hidePanel(panel) {
   if (panel) panel.style.display = 'none';
 }
 
+export function showDialogue(npc) {
+  const box = document.getElementById('dialogue-box');
+  const title = document.getElementById('dialogue-title');
+  const text = document.getElementById('dialogue-text');
+  const button = document.getElementById('dialogue-button');
+  if (!npc || !box || !title || !text || !button) return;
+  const prompt = document.getElementById('interact-prompt');
+  if (prompt) prompt.style.display = 'none';
+  title.textContent = npc.name;
+  text.textContent = npc.dialogue;
+  showPanel(box);
+  button.onclick = () => {
+    gameState.activeQuest = npc.quest;
+    const questTitle = document.getElementById('quest-title');
+    const questObjective = document.getElementById('quest-objective');
+    if (questTitle && npc.quest) questTitle.textContent = npc.quest.title;
+    if (questObjective && npc.quest)
+      questObjective.textContent = npc.quest.objective;
+    hidePanel(box);
+  };
+}
+
 export function initUI() {
   const startModal = document.getElementById('start-modal');
   const characterCreator = document.getElementById('character-creator');


### PR DESCRIPTION
## Summary
- add simple geometry-based NPCs with dialogue and quests
- expand village layout with more structures and NPC placement
- enable proximity-based NPC interaction and dialogue UI

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c557e11610832783a32802e8278436