### PR TITLE
feat: add village with player and UI

### DIFF
--- a/assets/sprites/villageStructures.js
+++ b/assets/sprites/villageStructures.js
@@ -16,7 +16,7 @@ export function createHut() {
   const roofHeight = 1.5;
   const roof = new THREE.Mesh(
     new THREE.ConeGeometry(2.2, roofHeight, 6),
-    new THREE.MeshStandardMaterial({ color: 0xCD853F })
+    new THREE.MeshStandardMaterial({ color: 0x8b0000 })
   );
   roof.position.y = baseHeight / 2 + roofHeight / 2;
   roof.castShadow = true;
@@ -82,7 +82,7 @@ export function createLordHouse() {
   const roofHeight = 2.5;
   const roof = new THREE.Mesh(
     new THREE.ConeGeometry(6, roofHeight, 4),
-    new THREE.MeshStandardMaterial({ color: 0x8B4513 })
+    new THREE.MeshStandardMaterial({ color: 0x8b0000 })
   );
   roof.position.y = baseHeight / 2 + roofHeight / 2;
   roof.castShadow = true;
@@ -150,7 +150,7 @@ export function createChurch() {
   const roofHeight = 3;
   const roof = new THREE.Mesh(
     new THREE.ConeGeometry(5, roofHeight, 4),
-    new THREE.MeshStandardMaterial({ color: 0x8B0000 })
+    new THREE.MeshStandardMaterial({ color: 0x8b0000 })
   );
   roof.position.y = baseHeight / 2 + roofHeight / 2;
   roof.castShadow = true;

--- a/index.html
+++ b/index.html
@@ -63,11 +63,17 @@
                 <p class="mt-2 text-sm">Attack: <span id="player-attack"></span></p>
                 <p class="text-sm">Health: <span id="player-health"></span></p>
                 <p class="text-sm">Speed: <span id="player-speed"></span></p>
-                <p id="quest-title" class="mt-3">No active quest.</p>
-                <p id="quest-objective">The Village Elder seems troubled. Perhaps they have a story to tell.</p>
+                <ul id="equipment-slots" class="text-sm mt-2">
+                    <li>Head: <span id="slot-head">Empty</span></li>
+                    <li>Chest: <span id="slot-chest">Empty</span></li>
+                    <li>Weapon: <span id="slot-weapon">Empty</span></li>
+                </ul>
+                <div id="active-quests" class="mt-3 text-sm">
+                    <p id="quest-title">No active quest.</p>
+                    <p id="quest-objective">The Village Elder seems troubled. Perhaps they have a story to tell.</p>
+                </div>
                 <div class="flex flex-col gap-2 mt-3">
-                    <button id="open-journal-btn" class="text-sm p-1">Open Journal</button>
-                    <button id="open-gear-btn" class="text-sm p-1">Gear & Equipment</button>
+                    <button id="open-journal-inventory-btn" class="text-sm p-1">Journal & Inventory</button>
                     <button id="save-game-btn" class="text-sm p-1">Save Game</button>
                 </div>
             </div>
@@ -193,18 +199,12 @@
             </div>
             <div id="journal-entries"></div>
             <div id="achievements-list" style="display: none;"></div>
+            <h2 class="text-xl mt-4">Inventory</h2>
+            <div id="inventory-list" class="space-y-2"></div>
             <div class="flex justify-center gap-4 mt-4">
                 <button id="copy-journal-btn">Copy Story</button>
                 <button id="close-journal-btn">Close</button>
             </div>
-        </div>
-
-        <!-- Gear Panel -->
-        <div id="gear-panel" class="ui-panel" role="dialog" aria-modal="true" aria-labelledby="gear-heading">
-            <h1 id="gear-heading" class="text-2xl">Gear & Equipment</h1>
-            <div id="equipped-readout" class="mb-3 text-sm"></div>
-            <div id="inventory-list" class="space-y-2"></div>
-            <div class="flex justify-center gap-3 mt-3"><button id="close-gear-btn">Close</button></div>
         </div>
 
         <!-- Loot Modal -->

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,0 +1,54 @@
+import * as THREE from 'three';
+
+export function createPath(length = 5, width = 2) {
+  const geometry = new THREE.PlaneGeometry(length, width, 1, 1);
+  const material = new THREE.MeshStandardMaterial({ color: 0xc2b280 });
+  const path = new THREE.Mesh(geometry, material);
+  path.rotation.x = -Math.PI / 2;
+  path.receiveShadow = true;
+  return path;
+}
+
+export function createFence(planks = 5) {
+  const group = new THREE.Group();
+  const material = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
+  for (let i = 0; i < planks; i++) {
+    const plank = new THREE.Mesh(
+      new THREE.BoxGeometry(0.2, 1, 0.5),
+      material
+    );
+    plank.position.set(i * 0.5, 0.5, 0);
+    plank.castShadow = true;
+    group.add(plank);
+  }
+  return group;
+}
+
+export function createTree() {
+  const group = new THREE.Group();
+  const trunk = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.2, 0.3, 2, 8),
+    new THREE.MeshStandardMaterial({ color: 0x8b4513 })
+  );
+  trunk.position.y = 1;
+  trunk.castShadow = trunk.receiveShadow = true;
+  group.add(trunk);
+
+  const canopy = new THREE.Mesh(
+    new THREE.SphereGeometry(1, 8, 8),
+    new THREE.MeshStandardMaterial({ color: 0x228b22 })
+  );
+  canopy.position.y = 2.5;
+  canopy.castShadow = true;
+  group.add(canopy);
+
+  return group;
+}
+
+export function createRock() {
+  const geometry = new THREE.DodecahedronGeometry(0.5, 0);
+  const material = new THREE.MeshStandardMaterial({ color: 0x808080 });
+  const rock = new THREE.Mesh(geometry, material);
+  rock.castShadow = rock.receiveShadow = true;
+  return rock;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { initRenderer, scene, camera, renderer } from './render.js';
 import { initUI } from './ui.js';
 import { initControls, updateControls } from './controls.js';
+import { createPlayer } from './player.js';
 import { gameState, saveGame, loadGame, checkForSavedGame } from './state.js';
 
 /**
@@ -15,8 +16,10 @@ function animate() {
 
 export function startGame() {
   initRenderer();
+  const player = createPlayer();
+  scene.add(player);
   initUI();
-  initControls(camera);
+  initControls(camera, player);
   animate();
 }
 

--- a/src/npcs.js
+++ b/src/npcs.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { showDialogue } from './ui.js';
 
-function createNPC(name, color, dialogue, quest) {
+function createNPC(name, color, dialogue, quest, radius = 2) {
   const group = new THREE.Group();
 
   const body = new THREE.Mesh(
@@ -25,6 +25,7 @@ function createNPC(name, color, dialogue, quest) {
     mesh: group,
     dialogue,
     quest,
+    radius,
     triggerDialogue() {
       showDialogue({ name, dialogue, quest });
     },

--- a/src/player.js
+++ b/src/player.js
@@ -1,0 +1,19 @@
+import * as THREE from 'three';
+
+export function createPlayer() {
+  const group = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.5, 0.5, 2, 12),
+    new THREE.MeshStandardMaterial({ color: 0x0077ff })
+  );
+  body.castShadow = body.receiveShadow = true;
+  group.add(body);
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.4, 16, 16),
+    new THREE.MeshStandardMaterial({ color: 0xffe0bd })
+  );
+  head.position.y = 1.2;
+  head.castShadow = true;
+  group.add(head);
+  return group;
+}

--- a/src/render.js
+++ b/src/render.js
@@ -11,6 +11,7 @@ import {
   createFisherman,
   createSageOfTheTides,
 } from './npcs.js';
+import { createPath, createFence, createTree, createRock } from './environment.js';
 
 export let scene;
 export let camera;
@@ -51,11 +52,11 @@ export function initRenderer(container = document.body) {
   // Add simple lighting so that meshes using standard materials are visible
   // when the scene initializes. Without at least an ambient light the imported
   // models render completely black, which made characters appear to be missing.
-  const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+  const ambient = new THREE.AmbientLight(0xffffff, 0.8);
   scene.add(ambient);
 
-  const directional = new THREE.DirectionalLight(0xffffff, 0.8);
-  directional.position.set(5, 10, 7.5);
+  const directional = new THREE.DirectionalLight(0xfff0e0, 1.0);
+  directional.position.set(10, 15, 10);
   scene.add(directional);
 
   window.addEventListener('resize', handleResize);
@@ -78,53 +79,90 @@ export function populateVillage(targetScene = scene) {
   ground.receiveShadow = true;
   targetScene.add(ground);
 
-  // Structures
+  // Winding path
+  const path1 = createPath(12, 3);
+  path1.position.set(-8, 0.01, -2);
+  targetScene.add(path1);
+  const path2 = createPath(8, 3);
+  path2.rotation.y = Math.PI / 4;
+  path2.position.set(0, 0.01, 0);
+  targetScene.add(path2);
+  const path3 = createPath(6, 3);
+  path3.rotation.y = -Math.PI / 6;
+  path3.position.set(6, 0.01, 3);
+  targetScene.add(path3);
+
+  // Structures along the path
   const hut1 = createHut();
-  hut1.position.set(-5, 1, -2);
+  hut1.position.set(-6, 1, -4);
   targetScene.add(hut1);
 
   const hut2 = createHut();
-  hut2.position.set(8, 1, 4);
+  hut2.position.set(7, 1, 5);
+  hut2.rotation.y = Math.PI / 8;
   targetScene.add(hut2);
 
   const hut3 = createHut();
-  hut3.position.set(-10, 1, 3);
+  hut3.position.set(-2, 1, 2);
+  hut3.rotation.y = -Math.PI / 5;
   targetScene.add(hut3);
 
   const farm1 = createFarmRow();
-  farm1.position.set(-2, 0, -8);
+  farm1.position.set(-4, 0, -9);
   targetScene.add(farm1);
 
   const farm2 = createFarmRow();
-  farm2.position.set(5, 0, -9);
+  farm2.position.set(6, 0, -7);
   targetScene.add(farm2);
 
   const house1 = createLordHouse();
-  house1.position.set(5, 1.5, -2);
+  house1.position.set(3, 1.5, -3);
   house1.rotation.y = Math.PI / 4;
   targetScene.add(house1);
 
-  const house2 = createLordHouse();
-  house2.position.set(-6, 1.5, 6);
-  house2.rotation.y = -Math.PI / 6;
-  targetScene.add(house2);
-
   const church = createChurch();
-  church.position.set(-8, 3, -2);
-  church.rotation.y = -Math.PI / 2;
+  church.position.set(-9, 3, 1);
+  church.rotation.y = Math.PI / 2;
   targetScene.add(church);
+
+  // Fences
+  const fence1 = createFence(8);
+  fence1.position.set(-10, 0, -2);
+  fence1.rotation.y = Math.PI / 2;
+  targetScene.add(fence1);
+  const fence2 = createFence(10);
+  fence2.position.set(2, 0, -10);
+  targetScene.add(fence2);
+
+  // Trees and rocks
+  const tree1 = createTree();
+  tree1.position.set(-3, 0, -5);
+  targetScene.add(tree1);
+  const tree2 = createTree();
+  tree2.position.set(5, 0, 2);
+  targetScene.add(tree2);
+  const tree3 = createTree();
+  tree3.position.set(-7, 0, 4);
+  targetScene.add(tree3);
+
+  const rock1 = createRock();
+  rock1.position.set(1, 0, 3);
+  targetScene.add(rock1);
+  const rock2 = createRock();
+  rock2.position.set(-5, 0, 0);
+  targetScene.add(rock2);
 
   // NPCs
   const elder = createVillageElder();
-  elder.mesh.position.set(-8, 1, -4);
+  elder.mesh.position.set(-8, 1, -1);
   targetScene.add(elder.mesh);
 
   const fisherman = createFisherman();
-  fisherman.mesh.position.set(2, 1, -6);
+  fisherman.mesh.position.set(4, 1, -6);
   targetScene.add(fisherman.mesh);
 
   const sage = createSageOfTheTides();
-  sage.mesh.position.set(0, 1, 4);
+  sage.mesh.position.set(1, 1, 4);
   targetScene.add(sage.mesh);
 
   registerNPCs([elder, fisherman, sage]);

--- a/src/state.js
+++ b/src/state.js
@@ -12,6 +12,7 @@ export const gameState = {
   selectedDomain: '',
   journalEntries: [],
   inventory: [],
+  equipment: { head: '', chest: '', weapon: '' },
   activeQuest: null,
 };
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,6 +6,21 @@
 
 import { gameState, saveGame, loadGame, checkForSavedGame } from './state.js';
 
+export function updateQuestLog() {
+  const head = document.getElementById('slot-head');
+  const chest = document.getElementById('slot-chest');
+  const weapon = document.getElementById('slot-weapon');
+  if (head) head.textContent = gameState.equipment.head || 'Empty';
+  if (chest) chest.textContent = gameState.equipment.chest || 'Empty';
+  if (weapon) weapon.textContent = gameState.equipment.weapon || 'Empty';
+
+  const title = document.getElementById('quest-title');
+  const objective = document.getElementById('quest-objective');
+  if (title && gameState.activeQuest) title.textContent = gameState.activeQuest.title;
+  if (objective && gameState.activeQuest)
+    objective.textContent = gameState.activeQuest.objective;
+}
+
 export function showPanel(panel) {
   if (panel) panel.style.display = 'block';
 }
@@ -27,11 +42,7 @@ export function showDialogue(npc) {
   showPanel(box);
   button.onclick = () => {
     gameState.activeQuest = npc.quest;
-    const questTitle = document.getElementById('quest-title');
-    const questObjective = document.getElementById('quest-objective');
-    if (questTitle && npc.quest) questTitle.textContent = npc.quest.title;
-    if (questObjective && npc.quest)
-      questObjective.textContent = npc.quest.objective;
+    updateQuestLog();
     hidePanel(box);
   };
 }
@@ -47,14 +58,13 @@ export function initUI() {
   const guardianTypeOptions = document.querySelectorAll('#guardian-type-options .creator-option');
   const guardianDomainOptions = document.querySelectorAll('#guardian-domain-options .creator-option');
   const customGuardianInput = document.getElementById('custom-guardian-input');
-  const openJournalBtn = document.getElementById('open-journal-btn');
+  const openJournalInventoryBtn = document.getElementById('open-journal-inventory-btn');
   const closeJournalBtn = document.getElementById('close-journal-btn');
   const journalPanel = document.getElementById('journal-panel');
   const journalEntries = document.getElementById('journal-entries');
-  const openGearBtn = document.getElementById('open-gear-btn');
-  const closeGearBtn = document.getElementById('close-gear-btn');
-  const gearPanel = document.getElementById('gear-panel');
   const inventoryList = document.getElementById('inventory-list');
+  const minimizeQuestLogBtn = document.getElementById('minimize-quest-log');
+  const questLogContent = document.getElementById('quest-log-content');
 
   let selectedGuardianType = '';
   let selectedDomain = '';
@@ -107,9 +117,9 @@ export function initUI() {
     });
   }
 
-  if (openJournalBtn && journalPanel) {
-    openJournalBtn.addEventListener('click', () => {
-      activeTrigger = openJournalBtn;
+  if (openJournalInventoryBtn && journalPanel) {
+    openJournalInventoryBtn.addEventListener('click', () => {
+      activeTrigger = openJournalInventoryBtn;
       if (journalEntries) {
         const entries =
           gameState.journalEntries && gameState.journalEntries.length
@@ -118,6 +128,15 @@ export function initUI() {
                 .join('')
             : '<p class="text-sm">Your journal is empty.</p>';
         journalEntries.innerHTML = entries;
+      }
+      if (inventoryList) {
+        const items =
+          gameState.inventory && gameState.inventory.length
+            ? gameState.inventory
+                .map((i) => `<div class="gear-item">${i}</div>`)
+                .join('')
+            : '<p class="text-sm">You have no gear.</p>';
+        inventoryList.innerHTML = items;
       }
       showPanel(journalPanel);
       closeJournalBtn && closeJournalBtn.focus();
@@ -132,34 +151,19 @@ export function initUI() {
     });
   }
 
-  if (openGearBtn && gearPanel) {
-    openGearBtn.addEventListener('click', () => {
-      activeTrigger = openGearBtn;
-      if (inventoryList) {
-        const items =
-          gameState.inventory && gameState.inventory.length
-            ? gameState.inventory
-                .map((i) => `<div class="gear-item">${i}</div>`)
-                .join('')
-            : '<p class="text-sm">You have no gear.</p>';
-        inventoryList.innerHTML = items;
-      }
-      showPanel(gearPanel);
-      closeGearBtn && closeGearBtn.focus();
-    });
-  }
-
-  if (closeGearBtn && gearPanel) {
-    closeGearBtn.addEventListener('click', () => {
-      hidePanel(gearPanel);
-      activeTrigger && activeTrigger.focus();
-      activeTrigger = null;
-    });
-  }
-
   if (saveGameBtn) {
     saveGameBtn.addEventListener('click', () => saveGame());
   }
+
+  if (minimizeQuestLogBtn && questLogContent) {
+    minimizeQuestLogBtn.addEventListener('click', () => {
+      const hidden = questLogContent.style.display === 'none';
+      questLogContent.style.display = hidden ? 'block' : 'none';
+      minimizeQuestLogBtn.textContent = hidden ? '-' : '+';
+    });
+  }
+
+  updateQuestLog();
 
   if (uiContainer) uiContainer.style.visibility = 'visible';
 


### PR DESCRIPTION
## Summary
- build environment helpers for paths, fences, trees and rocks
- introduce moveable guardian with third-person camera and NPC interaction
- expand quest log with equipment slots and combined journal/inventory panel
- remove binary textures in favor of flat color materials

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c55e43f9ac8327a99a0fcede8cf090