### PR TITLE
Fix OrbitControls import path for importmap

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -3,7 +3,7 @@
  * OrbitControls-based camera follow.
  */
 import * as THREE from 'three';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { gameState } from './state.js';
 import { setPointer, pick } from './picking.js';
 import { openDialoguePanel } from './ui.js';


### PR DESCRIPTION
## Summary
- fix OrbitControls import path to use three/addons alias for CDN importmap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c5f9d3f1a48327a933ecd1fd9dd777