### PR TITLE
Fix duplicate Three.js imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,8 +245,8 @@
     <script type="importmap">
         {
             "imports": {
-                "three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
-                "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/"
+                "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+                "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/"
             }
         }
     </script>

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import * as THREE from 'three';
 import {
   rockTexture,
   pathAlbedoTexture,


### PR DESCRIPTION
## Summary
- Load Three.js uniformly across the project to avoid multiple instance warnings
- Align import map with installed Three.js version

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5fd130dc883279006a512901dac5c