### PR TITLE
Add animated guardian model and player animation states

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -15,6 +15,13 @@ let orbit;
 const SPEED = 0.2;
 const prevPlayer = new THREE.Vector3();
 
+function fadeTo(action) {
+  if (!player || !action || player.currentAction === action) return;
+  if (player.currentAction) player.currentAction.fadeOut(0.2);
+  action.reset().fadeIn(0.2).play();
+  player.currentAction = action;
+}
+
 function onKeyDown(event) {
   keys[event.key.toLowerCase()] = true;
 }
@@ -56,9 +63,16 @@ export function updateControls() {
   if (keys['s']) move.sub(forward);
   if (keys['a']) move.add(left);
   if (keys['d']) move.sub(left);
-  if (move.lengthSq() > 0) {
+  const isMoving = move.lengthSq() > 0;
+  player.isMoving = isMoving;
+  if (isMoving) {
     move.normalize().multiplyScalar(SPEED);
     player.position.add(move);
+  }
+
+  if (player.actions && player.currentAction !== player.actions.interact) {
+    if (isMoving) fadeTo(player.actions.walk || player.actions.idle);
+    else fadeTo(player.actions.idle);
   }
 
   // Camera rotation via arrow keys
@@ -76,6 +90,9 @@ export function updateControls() {
   orbit.update();
 
   if (gameState.canInteractWith && keys['e']) {
+    if (player.actions && player.actions.interact) {
+      fadeTo(player.actions.interact);
+    }
     openDialoguePanel(gameState.canInteractWith.userData.name);
     keys['e'] = false;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ function animate() {
   if (!interactPrompt) interactPrompt = document.getElementById('interact-prompt');
   if (interactPrompt) interactPrompt.style.display = target ? 'block' : 'none';
   const delta = clock.getDelta();
+  if (player && player.mixer) player.mixer.update(delta);
   if (fxEnabled && composer) {
     composer.composer.render(delta);
   } else {

--- a/src/player.js
+++ b/src/player.js
@@ -1,19 +1,70 @@
 import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
 export function createPlayer() {
   const group = new THREE.Group();
-  const body = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.5, 0.5, 2, 12),
-    new THREE.MeshStandardMaterial({ color: 0x0077ff })
+  const loader = new GLTFLoader();
+  // guardianCharacter.glb should reside in assets/models/. If it is missing, a
+  // placeholder mesh is used so the game can still run without binary assets.
+  loader.load(
+    'assets/models/guardianCharacter.glb',
+    (gltf) => {
+      const model = gltf.scene;
+      model.traverse((child) => {
+        if (child.isMesh) {
+          child.castShadow = true;
+          child.receiveShadow = true;
+        }
+      });
+      group.add(model);
+
+      const mixer = new THREE.AnimationMixer(model);
+      const idleClip = THREE.AnimationClip.findByName(gltf.animations, 'Idle');
+      const walkClip =
+        THREE.AnimationClip.findByName(gltf.animations, 'Walk') ||
+        THREE.AnimationClip.findByName(gltf.animations, 'Run');
+      const interactClip =
+        THREE.AnimationClip.findByName(gltf.animations, 'Interact') ||
+        THREE.AnimationClip.findByName(gltf.animations, 'Wave');
+
+      const idleAction = idleClip ? mixer.clipAction(idleClip) : null;
+      const walkAction = walkClip ? mixer.clipAction(walkClip) : null;
+      const interactAction = interactClip ? mixer.clipAction(interactClip) : null;
+
+      if (interactAction) {
+        interactAction.loop = THREE.LoopOnce;
+        interactAction.clampWhenFinished = true;
+      }
+
+      if (idleAction) idleAction.play();
+
+      group.mixer = mixer;
+      group.actions = { idle: idleAction, walk: walkAction, interact: interactAction };
+      group.currentAction = idleAction;
+
+      if (interactAction) {
+        mixer.addEventListener('finished', (e) => {
+          if (e.action === interactAction) {
+            const next = group.isMoving && walkAction ? walkAction : idleAction;
+            if (group.currentAction !== next) {
+              interactAction.fadeOut(0.2);
+              next?.reset().fadeIn(0.2).play();
+              group.currentAction = next;
+            }
+          }
+        });
+      }
+    },
+  undefined,
+  () => {
+    const placeholder = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 2, 1),
+      new THREE.MeshStandardMaterial({ color: 0x808080 })
+    );
+    placeholder.castShadow = true;
+    placeholder.receiveShadow = true;
+    group.add(placeholder);
+  }
   );
-  body.castShadow = body.receiveShadow = true;
-  group.add(body);
-  const head = new THREE.Mesh(
-    new THREE.SphereGeometry(0.4, 16, 16),
-    new THREE.MeshStandardMaterial({ color: 0xffe0bd })
-  );
-  head.position.y = 1.2;
-  head.castShadow = true;
-  group.add(head);
   return group;
 }


### PR DESCRIPTION
## Summary
- replace placeholder guardian with Guardian character glb model and animation setup
- drive idle/walk/interact animations from controls
- update animation mixer each frame in main loop
- remove embedded binary asset and load external model with a placeholder fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c6196fc744832794ed312c1efde40f