### PR TITLE
Integrate PlayerModel with movement, camera, and interactions

### DIFF
--- a/src/playerModel.js
+++ b/src/playerModel.js
@@ -1,20 +1,20 @@
 // src/playerModel.js
 
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
 export class PlayerModel {
   constructor(scene, options = {}) {
     this.scene = scene;
+    this.group = new THREE.Group();
+    this.scene.add(this.group);
+
     this.model = null;
     this.mixer = null;
-    this.actions = {
-      idle: null,
-      walk: null,
-      interact: null,
-    };
+    this.actions = { idle: null, walk: null, interact: null };
     this.currentAction = null;
-    this.clock = new THREE.Clock();
+    this.state = { yaw: 0, pitch: 0 };
+    this.isMoving = false;
 
     this.loadModel(options.modelPath || 'assets/models/guardianCharacter.glb');
   }
@@ -25,58 +25,84 @@ export class PlayerModel {
       path,
       (gltf) => {
         this.model = gltf.scene;
-        this.model.traverse(child => {
+        this.model.traverse((child) => {
           if (child.isMesh) {
             child.castShadow = true;
             child.receiveShadow = true;
           }
         });
-        this.scene.add(this.model);
+        this.group.add(this.model);
 
         // setup animation mixer
         this.mixer = new THREE.AnimationMixer(this.model);
 
         // find clips by name (adjust names to match your GLB)
-        const idleClip     = THREE.AnimationClip.findByName(gltf.animations, 'Idle');
-        const walkClip     = THREE.AnimationClip.findByName(gltf.animations, 'Walk');
-        const interactClip = THREE.AnimationClip.findByName(gltf.animations, 'Interact');
+        const idleClip = THREE.AnimationClip.findByName(gltf.animations, 'Idle');
+        const walkClip = THREE.AnimationClip.findByName(gltf.animations, 'Walk');
+        const interactClip = THREE.AnimationClip.findByName(
+          gltf.animations,
+          'Interact'
+        );
 
-        if (idleClip)     this.actions.idle     = this.mixer.clipAction(idleClip);
-        if (walkClip)     this.actions.walk     = this.mixer.clipAction(walkClip);
-        if (interactClip) this.actions.interact = this.mixer.clipAction(interactClip);
+        if (idleClip) this.actions.idle = this.mixer.clipAction(idleClip);
+        if (walkClip) this.actions.walk = this.mixer.clipAction(walkClip);
+        if (interactClip) {
+          const action = this.mixer.clipAction(interactClip);
+          action.loop = THREE.LoopOnce;
+          action.clampWhenFinished = true;
+          this.actions.interact = action;
+        }
 
         // Start idle by default
         if (this.actions.idle) {
           this.currentAction = this.actions.idle;
           this.currentAction.play();
         }
+
+        // revert to idle/walk when interaction finishes
+        if (this.actions.interact) {
+          this.mixer.addEventListener('finished', (e) => {
+            if (e.action === this.actions.interact) {
+              const next = this.isMoving && this.actions.walk
+                ? this.actions.walk
+                : this.actions.idle;
+              next?.reset().fadeIn(0.2).play();
+              this.currentAction = next;
+            }
+          });
+        }
       },
-      undefined, 
+      undefined,
       (error) => {
         console.error('Error loading player model:', error);
       }
     );
   }
 
-  update() {
-    const delta = this.clock.getDelta();
+  update(delta) {
+    const d = delta !== undefined ? delta : 0;
     if (this.mixer) {
-      this.mixer.update(delta);
+      this.mixer.update(d);
     }
+  }
+
+  // rotate the player to face movement direction
+  setDirection(dir) {
+    if (!dir || dir.lengthSq() === 0) return;
+    const yaw = Math.atan2(dir.x, dir.z);
+    this.state.yaw = yaw;
+    this.group.rotation.y = yaw;
   }
 
   // Switches action, fading from current to new
   fadeTo(actionName, fadeDuration = 0.5) {
-    if (!this.actions[actionName]) return;
-    if (this.currentAction === this.actions[actionName]) return;
-
-    const prev = this.currentAction;
     const next = this.actions[actionName];
+    if (!next || this.currentAction === next) return;
 
     next.reset();
     next.play();
-    if (prev) {
-      prev.crossFadeTo(next, fadeDuration, false);
+    if (this.currentAction) {
+      this.currentAction.crossFadeTo(next, fadeDuration, false);
     }
 
     this.currentAction = next;


### PR DESCRIPTION
## Summary
- Instantiate `PlayerModel` within controls to drive player movement and animations
- Rotate and move player via `setDirection` and group position while camera follows
- Drive NPC interactions and animation updates through the new player instance
- Fix GLTFLoader import by using the `three/addons` path so modules resolve in browser

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c6226d4d848327813ebe10a2d66b45