### PR TITLE
Specify ESM format in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test",
-    "build": "esbuild src/main.js --bundle --outdir=dist && cp index.html offline.html service-worker.js dist/ && cp -r assets dist/"
+    "build": "esbuild src/main.js --bundle --format=esm --outdir=dist && cp index.html offline.html service-worker.js dist/ && cp -r assets dist/"
   },
   "devDependencies": {
     "esbuild": "^0.19.2"


### PR DESCRIPTION
## Summary
- build esbuild bundle as ESM modules

## Testing
- `npm test`
- `npm run build`
- `node <<'NODE'
const {chromium} = require('playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  page.on('pageerror', err => console.error('pageerror:', err));
  await page.goto('file://' + process.cwd() + '/dist/index.html');
  await page.waitForTimeout(1000);
  console.log('page loaded');
  await browser.close();
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_b_68c6727baa788327837b64673ffe5a31