### PR TITLE
Add start screen setup and character creator flow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -111,13 +111,93 @@ export async function startGame() {
   animate();
 }
 
+/**
+ * Prepare the initial start screen and character creator before the game
+ * begins. Handles button clicks for starting a new game or continuing an
+ * existing one.
+ */
+function setupStartScreen() {
+  const startModal = document.getElementById('start-modal');
+  const characterCreator = document.getElementById('character-creator');
+  const uiContainer = document.getElementById('ui-container');
+  const newGameBtn = document.getElementById('new-game-btn');
+  const continueGameBtn = document.getElementById('continue-game-btn');
+  const startGameBtn = document.getElementById('start-game-btn');
+
+  if (!startModal || !characterCreator || !uiContainer) {
+    // Fallback: if the expected UI elements aren't present, start immediately.
+    startGame();
+    return;
+  }
+
+  // Enable continue button only if a saved game exists.
+  continueGameBtn.disabled = !checkForSavedGame();
+
+  // Show character creator when forging a new legend.
+  newGameBtn.addEventListener('click', () => {
+    startModal.style.display = 'none';
+    characterCreator.style.display = 'block';
+  });
+
+  // Load saved state and begin the game when continuing a journey.
+  continueGameBtn.addEventListener('click', () => {
+    const saved = loadGame();
+    if (saved) Object.assign(gameState, saved);
+    startModal.style.display = 'none';
+    uiContainer.style.visibility = 'visible';
+    startGame();
+  });
+
+  // Begin the adventure after selecting a guardian and domain.
+  startGameBtn.addEventListener('click', () => {
+    const guardianEl = document.querySelector('#guardian-type-options .selected');
+    const domainEl = document.querySelector('#guardian-domain-options .selected');
+    const customInput = document.getElementById('custom-guardian-input');
+
+    gameState.selectedGuardian = '';
+    gameState.selectedDomain = '';
+
+    if (guardianEl) {
+      if (guardianEl.dataset.type === 'custom' && customInput) {
+        gameState.selectedGuardian = customInput.value.trim();
+      } else {
+        gameState.selectedGuardian = guardianEl.dataset.type || '';
+      }
+    }
+
+    if (domainEl) {
+      gameState.selectedDomain = domainEl.dataset.domain || '';
+    }
+
+    characterCreator.style.display = 'none';
+    uiContainer.style.visibility = 'visible';
+    startGame();
+  });
+
+  // Optional: toggle "selected" class for guardian and domain options.
+  function enableSelection(containerSelector) {
+    const container = document.querySelector(containerSelector);
+    if (!container) return;
+    const options = container.querySelectorAll('.creator-option');
+    options.forEach((opt) => {
+      opt.addEventListener('click', () => {
+        options.forEach((o) => o.classList.remove('selected'));
+        opt.classList.add('selected');
+      });
+    });
+  }
+
+  enableSelection('#guardian-type-options');
+  enableSelection('#guardian-domain-options');
+}
+
 // Wait for the DOM to be fully loaded before starting the game.
 // This ensures UI elements like the "Forge New Legend" button exist
 // when event listeners are registered.
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', startGame);
+  document.addEventListener('DOMContentLoaded', setupStartScreen);
 } else {
-  startGame();
+  setupStartScreen();
 }
 
 // Re-export state helpers so they can be accessed from other modules if needed.


### PR DESCRIPTION
## Summary
- Add `setupStartScreen` to manage start modal, character creation, and saved-game handling
- Enable visual selection for guardian and domain options
- Start game only after player chooses new or continues saved game

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c674ef32108327adb7735782b86588