### PR TITLE
Fix player model 404 without bundling binary asset

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v5';
+const CACHE_VERSION = 'v8';
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const BASE_PATH = self.location.pathname.replace(/service-worker\.js$/, '');
 const ASSETS = [
@@ -10,7 +10,6 @@ const ASSETS = [
   `${BASE_PATH}src/npcs.js`,
   `${BASE_PATH}src/models.js`,
   `${BASE_PATH}src/loaders.js`,
-  `${BASE_PATH}assets/models/`,
   `${BASE_PATH}assets/textures/`,
   `${BASE_PATH}assets/env/`,
   `${BASE_PATH}libs/draco/`,

--- a/src/playerModel.js
+++ b/src/playerModel.js
@@ -17,17 +17,24 @@ export class PlayerModel {
     this.state = { yaw: 0, pitch: 0 };
     this.isMoving = false;
 
-    // Use provided model path or default to hosted asset.
-    this.loadModel(
-      options.modelPath ||
-        'https://dmaher42.github.io/Write-the-Realm/assets/models/guardianCharacter.glb'
-    );
+    // Use provided model path or fall back to a simple placeholder mesh.
+    this.loadModel(options.modelPath);
   }
 
-  loadModel(path) {
+  loadModel(modelPath) {
+    if (!modelPath) {
+      // Fallback placeholder: a simple box mesh so the game can run without a GLB.
+      const geometry = new THREE.BoxGeometry(1, 1, 1);
+      const material = new THREE.MeshStandardMaterial({ color: 0xcccccc });
+      this.model = new THREE.Mesh(geometry, material);
+      this.group.add(this.model);
+      return;
+    }
+
     const loader = new GLTFLoader();
+    const modelUrl = new URL(modelPath, import.meta.url).toString();
     loader.load(
-      path,
+      modelUrl,
       (gltf) => {
         this.model = gltf.scene;
         this.group.add(this.model);


### PR DESCRIPTION
## Summary
- drop binary guardian model file and generate a placeholder mesh when no model is supplied
- load external models only when a path is provided
- remove model from service worker cache list and bump cache to v8

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c6746df7988327872340a797673c22