### PR TITLE
Fix Three.js module imports for RGBELoader and other loaders

### DIFF
--- a/src/loaders.js
+++ b/src/loaders.js
@@ -1,6 +1,6 @@
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
-import { KTX2Loader }  from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+import { KTX2Loader }  from 'three/addons/loaders/KTX2Loader.js';
 import * as THREE from 'three';
 
 export function makeGLTFLoader(renderer) {

--- a/src/render.js
+++ b/src/render.js
@@ -2,8 +2,8 @@ import * as THREE from 'three';
 import { spawnNPCs } from './npcs.js';
 import { createPath, createFence } from './environment.js';
 import { initModelLoader, spawnHut, spawnTree } from './models.js';
-import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
-import { PMREMGenerator } from 'three/src/extras/PMREMGenerator.js';
+import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
+import { PMREMGenerator } from 'three';
 
 export let scene;
 export let camera;


### PR DESCRIPTION
## Summary
- use `three/addons` prefix to import loaders
- import `PMREMGenerator` directly from `three`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c675ef92a08327a19c79735a2c1265