### PR TITLE
Fix PlayerModel initialization syntax error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -48,9 +48,11 @@ export async function startGame() {
   npcs = init.npcs;
 
   // Create animated GLTF player; use its group as the movable object
- playerModel = new PlayerModel(scene, {
-  modelPath: '../assets/models/viking.glb'
-  
+  playerModel = new PlayerModel(scene, {
+    modelPath: '../assets/models/viking.glb'
+  });
+  player = playerModel.group;
+
   initUI('#ui-root');
   setActionHandler(() => {
     // optional: update HUD/quest log here


### PR DESCRIPTION
## Summary
- close PlayerModel initialization and assign group to player in `startGame`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c684228f308327b179399959df13ac