### PR TITLE
fix: ensure orbit controls rotate methods exist

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -45,6 +45,10 @@ export function initControls(
   orbit.maxPolarAngle = Math.PI * 0.75;
   orbit.enableDamping = true;
   orbit.dampingFactor = 0.05;
+  if (!orbit.rotateLeft && orbit._rotateLeft)
+    orbit.rotateLeft = orbit._rotateLeft.bind(orbit);
+  if (!orbit.rotateUp && orbit._rotateUp)
+    orbit.rotateUp = orbit._rotateUp.bind(orbit);
   const targetObj = initControls.playerModel?.model ?? player;
   orbit.target.copy(targetObj.position);
   prevPlayer.copy(player.position);


### PR DESCRIPTION
## Summary
- make camera rotation compatible with OrbitControls versions that expose rotate methods privately

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c68f25e56883279c52e811ef0b462c