### PR TITLE
Fix player model orientation and size

### DIFF
--- a/src/playerModel.js
+++ b/src/playerModel.js
@@ -39,8 +39,8 @@ export class PlayerModel {
         this.model = gltf.scene;
         this.group.add(this.model);
 
-        this.model.scale.setScalar(1.0); // tweak per asset
-        this.model.rotation.y = Math.PI; // adjust if facing wrong way
+        this.model.scale.setScalar(0.5); // scale to roughly human height
+        this.model.rotation.y = 0; // asset already faces forward
         this.model.position.y = 0; // feet on ground
 
         this.model.traverse((child) => {


### PR DESCRIPTION
## Summary
- Scale the imported player model to human size.
- Remove the unnecessary 180° Y rotation so the model faces the correct direction.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c6913462648327abc1dccc3f77a1b3