### PR TITLE
feat: introduce animated NPC models

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { loadDialogue, getDialogueFor, open as openDialogue } from './dialogue.j
 import { initUI, setActionHandler } from './ui.js';
 import { initControls, updateControls } from './controls.js';
 import { PlayerModel } from './playerModel.js';
+import { npcModels } from './npcs.js';
 import { gameState, saveGame, loadGame, checkForSavedGame } from './state.js';
 import { createComposer } from './postfx.js';
 import { updatePointerFromEvent, pick, setPickTargets } from './picking.js';
@@ -36,6 +37,7 @@ function animate() {
   if (interactPrompt) interactPrompt.style.display = target ? 'block' : 'none';
   const delta = clock.getDelta();
   if (playerModel && playerModel.update) playerModel.update(delta);
+  for (const npc of npcModels) npc.update(delta);
   if (fxEnabled && composer) {
     composer.composer.render(delta);
   } else {
@@ -94,6 +96,9 @@ export async function startGame() {
     if (npcObj.position.distanceTo(playerPos) > (hovered.userData?.interactRadius ?? 2)) return;
 
     playerModel?.playOneShot('interact', 0.15, updateControls?._moving ? 'walk' : 'idle');
+
+    const npcModel = npcModels.find((n) => n.group === npcObj);
+    npcModel?.playOneShot('interact');
 
     const { lines, options } = getDialogueFor(target);
     openDialogue({ npcName: target, lines, options });

--- a/src/npcModel.js
+++ b/src/npcModel.js
@@ -1,0 +1,104 @@
+// src/npcModel.js
+
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { createNPC as createPrimitiveNPC } from './npcs.js';
+
+export class NPCModel {
+  constructor(scene, { name = 'NPC', position = new THREE.Vector3(), color = 0x8b4513, interactRadius = 2, modelPath = null } = {}) {
+    this.scene = scene;
+    this.group = new THREE.Group();
+    this.scene.add(this.group);
+    this.group.position.copy(position);
+    this.group.userData = { npcName: name, interactRadius, root: this.group };
+
+    this.model = null;
+    this.mixer = null;
+    this.actions = { idle: null, interact: null };
+    this.currentAction = null;
+
+    if (modelPath) {
+      this.loadModel(modelPath, color, interactRadius);
+    } else {
+      this.createFallback(color);
+    }
+  }
+
+  createFallback(color) {
+    const primitive = createPrimitiveNPC('npc', new THREE.Vector3(), color);
+    while (primitive.children.length) {
+      this.group.add(primitive.children[0]);
+    }
+  }
+
+  loadModel(modelPath, color, interactRadius) {
+    const loader = new GLTFLoader();
+    const url = new URL(modelPath, import.meta.url).toString();
+    loader.load(
+      url,
+      (gltf) => {
+        this.model = gltf.scene;
+        this.group.add(this.model);
+
+        this.model.scale.setScalar(0.5);
+        this.model.rotation.y = 0;
+        this.model.position.y = 0;
+
+        this.model.traverse((child) => {
+          if (child.isMesh) {
+            child.castShadow = true;
+            child.receiveShadow = true;
+            if (child.material) child.material.shadowSide = THREE.FrontSide;
+          }
+        });
+
+        this.mixer = new THREE.AnimationMixer(this.model);
+        const by = (n) => THREE.AnimationClip.findByName(gltf.animations, n);
+        const findLike = (k) => gltf.animations.find((a) => a.name.toLowerCase().includes(k.toLowerCase()));
+        const idleClip = by('Idle') || findLike('idle');
+        const interactClip = by('Interact') || findLike('interact') || findLike('wave') || findLike('talk');
+        this.actions.idle = idleClip ? this.mixer.clipAction(idleClip) : null;
+        this.actions.interact = interactClip ? this.mixer.clipAction(interactClip) : null;
+        if (this.actions.idle) {
+          this.currentAction = this.actions.idle;
+          this.currentAction.play();
+        }
+      },
+      undefined,
+      (err) => {
+        console.error('Error loading NPC model:', err);
+        this.createFallback(color);
+      }
+    );
+  }
+
+  update(delta) {
+    if (this.mixer) this.mixer.update(delta);
+  }
+
+  fadeTo(actionName, fadeDuration = 0.5) {
+    const next = this.actions[actionName];
+    if (!next || this.currentAction === next) return;
+    next.reset();
+    next.play();
+    if (this.currentAction) this.currentAction.crossFadeTo(next, fadeDuration, false);
+    this.currentAction = next;
+  }
+
+  playOneShot(name, fade = 0.2, then = 'idle') {
+    const act = this.actions[name];
+    if (!act) return;
+    const prev = this.currentAction;
+    act.reset().setLoop(THREE.LoopOnce, 1);
+    act.clampWhenFinished = true;
+    act.play();
+    if (prev) prev.crossFadeTo(act, fade, false);
+    const onFinished = (e) => {
+      if (e.action === act) {
+        this.mixer.removeEventListener('finished', onFinished);
+        this.fadeTo(then, 0.25);
+      }
+    };
+    this.mixer.addEventListener('finished', onFinished);
+  }
+}

--- a/src/npcs.js
+++ b/src/npcs.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { NPCModel } from './npcModel.js';
 
 export function createNPC(name, position, color = 0x8b4513, interactRadius = 2) {
   const group = new THREE.Group();
@@ -17,6 +18,7 @@ export function createNPC(name, position, color = 0x8b4513, interactRadius = 2) 
   );
   head.position.y = 1.25;
   head.castShadow = true;
+  head.receiveShadow = true;
   group.add(head);
 
   group.position.copy(position);
@@ -24,20 +26,37 @@ export function createNPC(name, position, color = 0x8b4513, interactRadius = 2) 
   return group;
 }
 
+export const npcModels = [];
+
 export function spawnNPCs(scene) {
   const list = [];
 
-  const elder = createNPC('Village Elder', new THREE.Vector3(-8, 1, -1), 0x8b4513);
-  scene.add(elder);
-  list.push(elder);
+  const elder = new NPCModel(scene, {
+    name: 'Village Elder',
+    position: new THREE.Vector3(-8, 1, -1),
+    color: 0x8b4513,
+    modelPath: '../assets/models/elder.glb',
+  });
+  npcModels.push(elder);
+  list.push(elder.group);
 
-  const fisherman = createNPC('Fisherman', new THREE.Vector3(4, 1, -6), 0x1e90ff);
-  scene.add(fisherman);
-  list.push(fisherman);
+  const fisherman = new NPCModel(scene, {
+    name: 'Fisherman',
+    position: new THREE.Vector3(4, 1, -6),
+    color: 0x1e90ff,
+    modelPath: '../assets/models/fisherman.glb',
+  });
+  npcModels.push(fisherman);
+  list.push(fisherman.group);
 
-  const sage = createNPC('Sage of the Tides', new THREE.Vector3(1, 1, 4), 0x228b22);
-  scene.add(sage);
-  list.push(sage);
+  const sage = new NPCModel(scene, {
+    name: 'Sage of the Tides',
+    position: new THREE.Vector3(1, 1, 4),
+    color: 0x228b22,
+    modelPath: '../assets/models/sage.glb',
+  });
+  npcModels.push(sage);
+  list.push(sage.group);
 
   return list;
 }


### PR DESCRIPTION
## Summary
- add NPCModel class to load GLB assets with idle/interact animations and shadow setup
- spawn NPCs using NPCModel with GLTF fallback to primitive meshes
- update main loop to tick NPC animations and trigger interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c6a10ba2108327be52f5a21fd5678f