### PR TITLE
Add Kokura Castle viewer panel with credits

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
 
     <!-- UI Container -->
     <div id="ui-container" style="visibility: hidden;">
+        <!-- 3D Realm Viewer -->
+        <div id="realm-3d" style="width: 420px; height: 300px; margin: 1rem auto;"></div>
         <!-- Quest Log -->
         <div id="quest-log" class="ui-panel" role="region" aria-labelledby="quest-heading">
             <button id="minimize-quest-log" class="minimize-btn" aria-label="Minimize quest log">-</button>
@@ -244,6 +246,11 @@
         <button id="message-button">OK</button>
     </div>
 
+    <div id="credits" style="text-align:center;font-size:0.75rem;margin-top:1rem;">
+        Kokura Castle by AVATTA — licensed under CC BY 4.0 (via Sketchfab).
+        <!-- TODO: Add model link -->
+    </div>
+
     <script type="importmap">
         {
             "imports": {
@@ -253,6 +260,7 @@
         }
     </script>
     <script type="module" src="./src/main.js"></script>
+    <script type="module" src="js/realmViewer.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/js/realmViewer.js
+++ b/js/realmViewer.js
@@ -1,0 +1,77 @@
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import { GLTFLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+import { KTX2Loader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'https://unpkg.com/three@0.160.0/examples/jsm/libs/meshopt_decoder.module.js';
+
+const container = document.getElementById('realm-3d');
+
+if (container) {
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  container.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+
+  const camera = new THREE.PerspectiveCamera(
+    45,
+    container.clientWidth / container.clientHeight,
+    0.1,
+    1000
+  );
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.8);
+  scene.add(ambient);
+
+  const dirLight = new THREE.DirectionalLight(0xffffff, 1);
+  dirLight.position.set(5, 10, 7.5);
+  scene.add(dirLight);
+
+  const loader = new GLTFLoader();
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  const ktx2 = new KTX2Loader()
+    .setTranscoderPath(
+      'https://unpkg.com/three@0.160.0/examples/jsm/libs/basis/'
+    )
+    .detectSupport(renderer);
+  loader.setKTX2Loader(ktx2);
+
+  loader.load(
+    'assets/models/KokuraCastle_opt.glb',
+    (gltf) => {
+      const model = gltf.scene;
+      const box = new THREE.Box3().setFromObject(model);
+      const size = box.getSize(new THREE.Vector3()).length();
+      const center = box.getCenter(new THREE.Vector3());
+      model.position.sub(center);
+      scene.add(model);
+
+      const dist = size * 0.9;
+      const height = size * 0.35;
+      camera.position.set(dist, height, dist);
+      camera.lookAt(0, 0, 0);
+    },
+    undefined,
+    (err) => {
+      console.error('Failed to load GLB:', 'assets/models/KokuraCastle_opt.glb', err);
+    }
+  );
+
+  const resizeObserver = new ResizeObserver(() => {
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+    renderer.setSize(width, height);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  });
+  resizeObserver.observe(container);
+
+  function animate() {
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+  }
+  animate();
+} else {
+  console.error('Container #realm-3d not found');
+}
+


### PR DESCRIPTION
## Summary
- Embed a Three.js viewer panel that loads an optimized Kokura Castle model with Meshopt and KTX2 support.
- Add a visible 420x300 container, module import, and attribution footer for the model.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c6a840e73c83278b6f6da1c94fcee9