### PR TITLE
Guard 3D model loading and unify Three.js version

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,8 +254,8 @@
     <script type="importmap">
         {
             "imports": {
-                "three": "https://unpkg.com/three@0.158.0/build/three.module.js",
-                "three/addons/": "https://unpkg.com/three@0.158.0/examples/jsm/"
+                "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+                "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
             }
         }
     </script>

--- a/js/realmViewer.js
+++ b/js/realmViewer.js
@@ -1,7 +1,7 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { GLTFLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
-import { KTX2Loader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/KTX2Loader.js';
-import { MeshoptDecoder } from 'https://unpkg.com/three@0.160.0/examples/jsm/libs/meshopt_decoder.module.js';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 
 const container = document.getElementById('realm-3d');
 
@@ -36,26 +36,35 @@ if (container) {
     .detectSupport(renderer);
   loader.setKTX2Loader(ktx2);
 
-  loader.load(
-    'assets/models/KokuraCastle_opt.glb',
-    (gltf) => {
-      const model = gltf.scene;
-      const box = new THREE.Box3().setFromObject(model);
-      const size = box.getSize(new THREE.Vector3()).length();
-      const center = box.getCenter(new THREE.Vector3());
-      model.position.sub(center);
-      scene.add(model);
+  const useModels =
+    typeof window !== 'undefined' && window.USE_3D_MODELS;
 
-      const dist = size * 0.9;
-      const height = size * 0.35;
-      camera.position.set(dist, height, dist);
-      camera.lookAt(0, 0, 0);
-    },
-    undefined,
-    (err) => {
-      console.error('Failed to load GLB:', 'assets/models/KokuraCastle_opt.glb', err);
-    }
-  );
+  if (useModels) {
+    loader.load(
+      'assets/models/KokuraCastle_opt.glb',
+      (gltf) => {
+        const model = gltf.scene;
+        const box = new THREE.Box3().setFromObject(model);
+        const size = box.getSize(new THREE.Vector3()).length();
+        const center = box.getCenter(new THREE.Vector3());
+        model.position.sub(center);
+        scene.add(model);
+
+        const dist = size * 0.9;
+        const height = size * 0.35;
+        camera.position.set(dist, height, dist);
+        camera.lookAt(0, 0, 0);
+      },
+      undefined,
+      (err) => {
+        console.error(
+          'Failed to load GLB:',
+          'assets/models/KokuraCastle_opt.glb',
+          err
+        );
+      }
+    );
+  }
 
   const resizeObserver = new ResizeObserver(() => {
     const width = container.clientWidth;

--- a/src/npcs.js
+++ b/src/npcs.js
@@ -30,12 +30,13 @@ export const npcModels = [];
 
 export function spawnNPCs(scene) {
   const list = [];
+  const useModels = typeof window !== 'undefined' && window.USE_3D_MODELS;
 
   const elder = new NPCModel(scene, {
     name: 'Village Elder',
     position: new THREE.Vector3(-8, 1, -1),
     color: 0x8b4513,
-    modelPath: '../assets/models/elder.glb',
+    modelPath: useModels ? '../assets/models/elder.glb' : null,
   });
   npcModels.push(elder);
   list.push(elder.group);
@@ -44,7 +45,7 @@ export function spawnNPCs(scene) {
     name: 'Fisherman',
     position: new THREE.Vector3(4, 1, -6),
     color: 0x1e90ff,
-    modelPath: '../assets/models/fisherman.glb',
+    modelPath: useModels ? '../assets/models/fisherman.glb' : null,
   });
   npcModels.push(fisherman);
   list.push(fisherman.group);
@@ -53,7 +54,7 @@ export function spawnNPCs(scene) {
     name: 'Sage of the Tides',
     position: new THREE.Vector3(1, 1, 4),
     color: 0x228b22,
-    modelPath: '../assets/models/sage.glb',
+    modelPath: useModels ? '../assets/models/sage.glb' : null,
   });
   npcModels.push(sage);
   list.push(sage.group);


### PR DESCRIPTION
## Summary
- ensure NPC and realm models only load when `window.USE_3D_MODELS` is enabled
- align import map and viewer to a single Three.js instance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c6a976638c8327aef6196572f5793d