### PR TITLE
Add interactive Kokura Village starter scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 
     <div id="ui-root"></div>
 
+    <div id="kokura-root" style="width:100%;max-width:960px;height:420px;margin:auto;"></div>
+
     <!-- Start Modal -->
     <div id="start-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="start-heading">
         <div class="modal-content">
@@ -246,10 +248,10 @@
         <button id="message-button">OK</button>
     </div>
 
-    <div id="credits" style="text-align:center;font-size:0.75rem;margin-top:1rem;">
+    <footer id="credits" style="text-align:center;font-size:0.75rem;margin-top:1rem;">
         Kokura Castle by AVATTA — licensed under CC BY 4.0 (via Sketchfab).
-        <!-- TODO: Add model link -->
-    </div>
+        <!-- TODO: add model + license links -->
+    </footer>
 
     <script type="importmap">
         {
@@ -261,6 +263,14 @@
     </script>
     <script type="module" src="./src/main.js"></script>
     <script type="module" src="js/realmViewer.js"></script>
+    <script type="module">
+        import { mountKokuraVillage } from './js/KokuraVillageScene.js';
+        const gameAPI = { openQuest, grantLoot, setFlag, refreshUI, ...(window.gameAPI || {}) };
+        const root = document.getElementById('kokura-root');
+        if (root) {
+            mountKokuraVillage(root, gameAPI);
+        }
+    </script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/js/KokuraVillageScene.js
+++ b/js/KokuraVillageScene.js
@@ -1,0 +1,121 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
+
+export function mountKokuraVillage(container, game) {
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  container.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+
+  const camera = new THREE.PerspectiveCamera(
+    45,
+    container.clientWidth / container.clientHeight,
+    0.1,
+    300
+  );
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+  scene.add(ambient);
+
+  const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+  dirLight.position.set(5, 10, 7.5);
+  scene.add(dirLight);
+
+  const resizeObserver = new ResizeObserver(() => {
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+    renderer.setSize(width, height);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  });
+  resizeObserver.observe(container);
+
+  const loader = new GLTFLoader();
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  const ktx2 = new KTX2Loader()
+    .setTranscoderPath('https://unpkg.com/three@0.160.0/examples/jsm/libs/basis/')
+    .detectSupport(renderer);
+  loader.setKTX2Loader(ktx2);
+
+  const hotspots = [];
+  const raycaster = new THREE.Raycaster();
+  const pointer = new THREE.Vector2();
+
+  function handlePointer(event) {
+    const rect = renderer.domElement.getBoundingClientRect();
+    pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    raycaster.setFromCamera(pointer, camera);
+    const hits = raycaster.intersectObjects(hotspots, false);
+    if (hits.length > 0) {
+      const name = hits[0].object.name;
+      if (name === 'Hotspot_Gate') {
+        game?.openQuest?.('Welcome to Kokura');
+      } else if (name === 'Hotspot_KeepDoor') {
+        game?.grantLoot?.('Shrine Key');
+      } else if (name === 'Hotspot_Market') {
+        if (game?.openShop) {
+          game.openShop('starter');
+        } else {
+          game?.refreshUI?.();
+        }
+      } else if (name === 'Hotspot_Shrine') {
+        game?.setFlag?.('kokura.shrine.unlocked', true);
+      }
+      game?.refreshUI?.();
+    }
+  }
+  renderer.domElement.addEventListener('pointerdown', handlePointer);
+
+  loader.load(
+    './assets/models/KokuraVillage_opt.glb',
+    (gltf) => {
+      const root = gltf.scene;
+      scene.add(root);
+      const box = new THREE.Box3().setFromObject(root);
+      const size = box.getSize(new THREE.Vector3()).length();
+      const center = box.getCenter(new THREE.Vector3());
+      root.position.sub(center);
+
+      camera.position.set(0, size * 0.35, size * 0.95);
+      camera.lookAt(0, 0, 0);
+
+      const geo = new THREE.SphereGeometry(size * 0.05, 16, 16);
+      const mat = new THREE.MeshBasicMaterial({
+        color: 0xff0000,
+        transparent: true,
+        opacity: 0,
+      });
+
+      const positions = {
+        Hotspot_Gate: new THREE.Vector3(0, size * 0.05, size * 0.5),
+        Hotspot_KeepDoor: new THREE.Vector3(0, size * 0.05, -size * 0.2),
+        Hotspot_Market: new THREE.Vector3(-size * 0.3, size * 0.05, size * 0.1),
+        Hotspot_Shrine: new THREE.Vector3(size * 0.3, size * 0.05, -size * 0.1),
+      };
+
+      Object.entries(positions).forEach(([name, pos]) => {
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.name = name;
+        mesh.position.copy(pos);
+        root.add(mesh);
+        hotspots.push(mesh);
+      });
+    },
+    undefined,
+    (err) => {
+      console.error('Failed to load KokuraVillage_opt.glb', err);
+    }
+  );
+
+  function animate() {
+    renderer.render(scene, camera);
+    requestAnimationFrame(animate);
+  }
+  animate();
+}


### PR DESCRIPTION
## Summary
- mount new Kokura Village Three.js scene with meshopt+KTX2 support
- wire raycast hotspots to existing quest/loot/state APIs
- embed scene container and boot script on start page with CC-BY credit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c6aae6625c83279efe88f83e38acde