### PR TITLE
Use viking placeholder model for Kokura Village scene

### DIFF
--- a/js/KokuraVillageScene.js
+++ b/js/KokuraVillageScene.js
@@ -73,7 +73,7 @@ export function mountKokuraVillage(container, game) {
   renderer.domElement.addEventListener('pointerdown', handlePointer);
 
   loader.load(
-    './assets/models/KokuraVillage_opt.glb',
+    './assets/models/viking.glb',
     (gltf) => {
       const root = gltf.scene;
       scene.add(root);
@@ -109,7 +109,7 @@ export function mountKokuraVillage(container, game) {
     },
     undefined,
     (err) => {
-      console.error('Failed to load KokuraVillage_opt.glb', err);
+      console.error('Failed to load viking.glb', err);
     }
   );
 


### PR DESCRIPTION
## Summary
- drop missing Kokura Village model asset to keep repo free of binary models
- reference existing `viking.glb` so Kokura Village scene loads a placeholder without 404s

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c71c30f7a88327a92e7aa7a25c1cf3