### PR TITLE
Add illustrated castle to start screen

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -53,6 +53,50 @@
         #start-modal button:hover {
             background-color: var(--button-hover-bg);
         }
+        .start-modal-content {
+            flex-direction: column;
+            gap: 1.5rem;
+            align-items: center;
+        }
+        .castle-illustration {
+            width: min(420px, 80%);
+            margin: 0 auto;
+            filter: drop-shadow(0 20px 30px rgba(0,0,0,0.25));
+        }
+        .castle-illustration svg {
+            width: 100%;
+            height: auto;
+            display: block;
+        }
+        .start-modal-copy {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            gap: 1rem;
+        }
+        .start-modal-copy h1 {
+            margin-bottom: 0.5rem;
+        }
+        .start-modal-copy p {
+            margin: 0;
+        }
+        @media (min-width: 768px) {
+            .start-modal-content {
+                flex-direction: row;
+                justify-content: center;
+                text-align: left;
+            }
+            .start-modal-copy {
+                align-items: flex-start;
+                text-align: left;
+                max-width: 320px;
+            }
+            .start-modal-content .castle-illustration {
+                width: 45%;
+                margin: 0;
+            }
+        }
         .modal-content {
             background-color: var(--panel-bg); color: #3a2d21;
             padding: 1.5rem; border-radius: 10px; border: 2px solid var(--panel-border);

--- a/index.html
+++ b/index.html
@@ -16,12 +16,78 @@
 
     <!-- Start Modal -->
     <div id="start-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="start-heading">
-        <div class="modal-content">
-            <h1 id="start-heading" class="text-3xl mb-4">Welcome, Storyteller</h1>
-            <p class="mb-6">Your legend awaits. Will you forge a new path or continue an existing journey?</p>
-            <div class="flex flex-col sm:flex-row justify-center gap-4">
-                <button id="new-game-btn">Forge New Legend</button>
-                <button id="continue-game-btn" disabled>Continue Journey</button>
+        <div class="modal-content start-modal-content">
+            <div class="castle-illustration" aria-hidden="true">
+                <svg viewBox="0 0 480 320" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+                    <defs>
+                        <linearGradient id="castleSky" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="0%" stop-color="#a8d4f3" />
+                            <stop offset="100%" stop-color="#e6f1fb" />
+                        </linearGradient>
+                        <linearGradient id="castleStone" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="0%" stop-color="#f4ede2" />
+                            <stop offset="100%" stop-color="#d6c7b0" />
+                        </linearGradient>
+                        <linearGradient id="castleShadowStone" x1="0" y1="0" x2="1" y2="1">
+                            <stop offset="0%" stop-color="#d9c9ad" />
+                            <stop offset="100%" stop-color="#c4b499" />
+                        </linearGradient>
+                        <linearGradient id="castleRoof" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="0%" stop-color="#b35c5c" />
+                            <stop offset="100%" stop-color="#863b3b" />
+                        </linearGradient>
+                        <linearGradient id="castleDoor" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="0%" stop-color="#8d5b34" />
+                            <stop offset="100%" stop-color="#5c3b1e" />
+                        </linearGradient>
+                    </defs>
+                    <rect width="480" height="220" fill="url(#castleSky)" />
+                    <rect y="220" width="480" height="100" fill="#7bbd74" />
+                    <circle cx="90" cy="80" r="28" fill="#f6d46a" opacity="0.85" />
+                    <path d="M200 220 H280 L300 320 H180 Z" fill="#cba574" opacity="0.85" />
+                    <g>
+                        <rect x="108" y="126" width="64" height="116" rx="4" fill="url(#castleShadowStone)" />
+                        <rect x="308" y="126" width="64" height="116" rx="4" fill="url(#castleStone)" />
+                        <rect x="184" y="110" width="112" height="132" rx="4" fill="url(#castleStone)" />
+                        <rect x="184" y="100" width="112" height="14" fill="url(#castleShadowStone)" />
+                        <rect x="184" y="86" width="20" height="20" fill="url(#castleStone)" />
+                        <rect x="216" y="86" width="20" height="20" fill="url(#castleStone)" />
+                        <rect x="248" y="86" width="20" height="20" fill="url(#castleStone)" />
+                        <rect x="280" y="86" width="16" height="20" fill="url(#castleStone)" />
+                        <rect x="300" y="116" width="20" height="20" fill="url(#castleStone)" />
+                        <rect x="332" y="116" width="20" height="20" fill="url(#castleStone)" />
+                        <rect x="92" y="116" width="20" height="20" fill="url(#castleShadowStone)" />
+                        <rect x="124" y="116" width="20" height="20" fill="url(#castleShadowStone)" />
+                        <rect x="156" y="116" width="16" height="20" fill="url(#castleShadowStone)" />
+                        <rect x="136" y="156" width="20" height="28" rx="5" fill="#5c728c" />
+                        <rect x="340" y="156" width="20" height="28" rx="5" fill="#5c728c" />
+                        <rect x="232" y="146" width="24" height="32" rx="6" fill="#5c728c" />
+                        <rect x="232" y="190" width="24" height="32" rx="6" fill="#5c728c" />
+                        <rect x="238" y="204" width="48" height="68" rx="8" fill="url(#castleDoor)" />
+                        <circle cx="276" cy="238" r="4" fill="#d7b377" />
+                        <path d="M238 220 H286 L298 320 H226 Z" fill="#a97a4a" opacity="0.65" />
+                    </g>
+                    <g stroke="#704224" stroke-width="4" stroke-linecap="round">
+                        <line x1="140" y1="126" x2="140" y2="76" />
+                        <line x1="348" y1="126" x2="348" y2="76" />
+                    </g>
+                    <path d="M140 76 L176 88 L140 98 Z" fill="url(#castleRoof)" />
+                    <path d="M348 76 L384 88 L348 96 Z" fill="url(#castleRoof)" />
+                    <path d="M184 110 H296 L290 150 H190 Z" fill="rgba(255,255,255,0.1)" />
+                    <g fill="#5d8853" opacity="0.9">
+                        <circle cx="70" cy="230" r="24" />
+                        <circle cx="410" cy="236" r="26" />
+                        <circle cx="430" cy="250" r="18" />
+                    </g>
+                </svg>
+            </div>
+            <div class="start-modal-copy">
+                <h1 id="start-heading" class="text-3xl mb-4">Welcome, Storyteller</h1>
+                <p class="mb-6">Your legend awaits. Will you forge a new path or continue an existing journey?</p>
+                <div class="flex flex-col sm:flex-row justify-center sm:justify-start gap-4">
+                    <button id="new-game-btn">Forge New Legend</button>
+                    <button id="continue-game-btn" disabled>Continue Journey</button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- redesign the start modal to include a dedicated castle illustration
- center the intro copy beside the artwork and improve responsive layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca6126b1648324837d32740312699c